### PR TITLE
feat: per-hotel detail page with deep links, map/call actions, and QR targets

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -80,9 +80,49 @@
       background-color: #0056b3;
     }
 
+    .slug-preview {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      background-color: #eef2ff;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      font-size: 0.95rem;
+    }
+
+    .slug-preview strong {
+      font-size: 1rem;
+      color: #1f2933;
+    }
+
+    .slug-value {
+      font-family: 'Courier New', Courier, monospace;
+      font-weight: 600;
+      color: #4f46e5;
+      word-break: break-all;
+    }
+
+    .secondary-button {
+      flex: 0 0 auto;
+      min-width: 120px;
+      background-color: #4338ca;
+    }
+
+    .secondary-button:hover {
+      background-color: #312e81;
+    }
+
     .message {
       margin-top: 1rem;
       font-size: 0.95rem;
+      text-align: center;
+    }
+
+    .tip {
+      margin-top: 0.75rem;
+      font-size: 0.9rem;
+      color: #4338ca;
       text-align: center;
     }
   </style>
@@ -111,6 +151,21 @@
         <button type="submit">Save Hotel</button>
         <button type="button" id="preview-button">View Preview</button>
       </div>
+      <div class="slug-preview" id="slug-preview" hidden>
+        <div>
+          <strong>Recommended slug:</strong>
+          <span class="slug-value" id="slug-value"></span>
+        </div>
+        <button
+          type="button"
+          id="copy-slug-button"
+          class="secondary-button"
+          aria-label="Copy recommended slug"
+        >
+          Copy slug
+        </button>
+      </div>
+      <p class="tip" id="slug-tip" hidden>Add this hotel to hotels.json via PR later.</p>
       <p class="message" id="form-message" role="status" aria-live="polite"></p>
     </form>
   </div>
@@ -134,6 +189,16 @@
         const form = document.getElementById("hotel-form");
         const messageEl = document.getElementById("form-message");
         const previewButton = document.getElementById("preview-button");
+        const slugPreview = document.getElementById("slug-preview");
+        const slugValueEl = document.getElementById("slug-value");
+        const copySlugButton = document.getElementById("copy-slug-button");
+        const slugTip = document.getElementById("slug-tip");
+
+        const slugify = (value = "") =>
+          value
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "");
 
         const getFormData = () => {
           const name = document.getElementById("hotel-name").value.trim();
@@ -156,7 +221,50 @@
           }
         };
 
-        form.addEventListener("submit", (event) => {
+        const setSlugPreview = (slug) => {
+          if (!slugPreview || !slugValueEl || !slugTip || !copySlugButton) {
+            return;
+          }
+
+          if (!slug) {
+            slugPreview.hidden = true;
+            slugTip.hidden = true;
+            copySlugButton.disabled = true;
+            copySlugButton.removeAttribute("data-slug");
+            return;
+          }
+
+          slugPreview.hidden = false;
+          slugTip.hidden = false;
+          slugValueEl.textContent = slug;
+          copySlugButton.disabled = false;
+          copySlugButton.setAttribute("data-slug", slug);
+          copySlugButton.setAttribute("aria-label", `Copy recommended slug ${slug}`);
+        };
+
+        const copySlugToClipboard = async (slug) => {
+          if (!slug) {
+            return "No slug generated.";
+          }
+
+          try {
+            await navigator.clipboard.writeText(slug);
+            return `Recommended slug copied to clipboard: ${slug}`;
+          } catch (error) {
+            console.warn("Unable to copy slug automatically.", error);
+            return `Recommended slug ready: ${slug} (copy manually)`;
+          }
+        };
+
+        if (copySlugButton) {
+          copySlugButton.addEventListener("click", async () => {
+            const slug = copySlugButton.getAttribute("data-slug") || "";
+            const message = await copySlugToClipboard(slug);
+            showMessage(message);
+          });
+        }
+
+        form.addEventListener("submit", async (event) => {
           event.preventDefault();
           resetMessage();
 
@@ -182,7 +290,11 @@
             hotels.push(newHotel);
             window.localStorage.setItem("hotels", JSON.stringify(hotels));
 
-            showMessage("Hotel saved to local preview list.");
+            const recommendedSlug = slugify(name);
+            setSlugPreview(recommendedSlug);
+            const copyMessage = await copySlugToClipboard(recommendedSlug);
+
+            showMessage(`Hotel saved to local preview list. ${copyMessage}`);
             form.reset();
           } catch (error) {
             console.error("Failed to save hotel:", error);
@@ -193,6 +305,8 @@
         previewButton.addEventListener("click", () => {
           const previewData = getFormData();
           console.log("Preview hotel data:", previewData);
+          const previewSlug = slugify(previewData.name || "");
+          setSlugPreview(previewSlug);
           showMessage("Preview data logged to console.");
         });
       } else {

--- a/hotel.html
+++ b/hotel.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hotel Details | J1hub Experience</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: #f5f7fa;
+      color: #1f2933;
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 3rem;
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #4f46e5;
+      text-decoration: none;
+      font-weight: 600;
+      margin-bottom: 1.5rem;
+    }
+
+    .back-link:hover,
+    .back-link:focus {
+      text-decoration: underline;
+    }
+
+    .hotel-detail {
+      background: #fff;
+      border-radius: 18px;
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+      padding: 1.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    .hotel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+      color: #312e81;
+    }
+
+    .hotel-meta {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+
+    .hotel-meta strong {
+      color: #312e81;
+    }
+
+    .inline-link {
+      color: #4f46e5;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .inline-link:hover,
+    .inline-link:focus {
+      text-decoration: underline;
+    }
+
+    .hotel-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .action-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.65rem 1.2rem;
+      border-radius: 999px;
+      background: #4f46e5;
+      color: #fff;
+      text-decoration: none;
+      font-weight: 600;
+      min-height: 44px;
+      min-width: 120px;
+      transition: background 0.2s ease;
+    }
+
+    .action-button:hover,
+    .action-button:focus {
+      background: #4338ca;
+    }
+
+    .qr-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .qr-wrapper img {
+      width: 200px;
+      height: 200px;
+      border-radius: 12px;
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+    }
+
+    .qr-wrapper span {
+      font-size: 0.85rem;
+      color: #4b5563;
+    }
+
+    .message {
+      font-size: 1.05rem;
+      color: #4338ca;
+      background: #eef2ff;
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+    }
+
+    @media (max-width: 640px) {
+      .container {
+        padding: 1.5rem 1.125rem 2.5rem;
+      }
+
+      .hotel-header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .qr-wrapper {
+        width: 100%;
+        align-items: flex-start;
+      }
+
+      .action-button {
+        min-width: 100%;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <a class="back-link" href="index.html" aria-label="Return to hotel listings">&larr; Back to listings</a>
+    <section id="message" class="message" role="status" aria-live="polite" hidden></section>
+    <article id="hotel-detail" class="hotel-detail" hidden>
+      <div class="hotel-header">
+        <div class="hotel-info">
+          <h1 id="hotel-name"></h1>
+          <p id="hotel-description" class="hotel-meta"></p>
+        </div>
+        <div class="qr-wrapper">
+          <img id="hotel-qr" src="" alt="QR code for hotel detail" width="200" height="200" />
+          <span>Scan to open on your device</span>
+        </div>
+      </div>
+      <p id="hotel-address" class="hotel-meta"></p>
+      <p id="hotel-phone" class="hotel-meta"></p>
+      <p id="hotel-stay" class="hotel-meta"></p>
+      <div id="hotel-actions" class="hotel-actions"></div>
+    </article>
+  </main>
+  <script>
+    const slugify = (value = '') =>
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    const onlyDigits = (value = '') => String(value || '').replace(/\D+/g, '');
+    const encodeForURL = (value = '') => encodeURIComponent(String(value ?? ''));
+
+    const params = new URLSearchParams(window.location.search);
+    const slugParam = params.get('id');
+
+    const messageEl = document.getElementById('message');
+    const detailEl = document.getElementById('hotel-detail');
+    const nameEl = document.getElementById('hotel-name');
+    const descriptionEl = document.getElementById('hotel-description');
+    const addressEl = document.getElementById('hotel-address');
+    const phoneEl = document.getElementById('hotel-phone');
+    const stayEl = document.getElementById('hotel-stay');
+    const actionsEl = document.getElementById('hotel-actions');
+    const qrImage = document.getElementById('hotel-qr');
+
+    const showMessage = (text) => {
+      if (!messageEl) return;
+      messageEl.textContent = text;
+      messageEl.hidden = false;
+      if (detailEl) {
+        detailEl.hidden = true;
+      }
+    };
+
+    const showNotFound = () => {
+      showMessage('Hotel not found. Please return to the listings.');
+      if (messageEl) {
+        const backLink = document.createElement('a');
+        backLink.href = 'index.html';
+        backLink.textContent = 'Back to listings';
+        backLink.className = 'inline-link';
+        backLink.setAttribute('aria-label', 'Go back to hotel listings');
+        messageEl.appendChild(document.createTextNode(' '));
+        messageEl.appendChild(backLink);
+      }
+    };
+
+    const createActionButton = ({ href, text, ariaLabel, target, rel }) => {
+      const button = document.createElement('a');
+      button.className = 'action-button';
+      button.href = href;
+      button.textContent = text;
+      if (ariaLabel) {
+        button.setAttribute('aria-label', ariaLabel);
+      }
+      if (target) {
+        button.target = target;
+      }
+      if (rel) {
+        button.rel = rel;
+      }
+      return button;
+    };
+
+    const renderHotel = (hotel, slug) => {
+      if (!detailEl) return;
+
+      const mapLink = hotel.address
+        ? `https://www.google.com/maps/search/?api=1&query=${encodeForURL(hotel.address)}`
+        : '';
+      const phoneDigits = onlyDigits(hotel.phone || '');
+
+      detailEl.hidden = false;
+      if (messageEl) {
+        messageEl.hidden = true;
+      }
+
+      nameEl.textContent = hotel.name || 'Hotel';
+      document.title = `${hotel.name || 'Hotel'} | J1hub Experience`;
+
+      if (descriptionEl) {
+        descriptionEl.textContent = hotel.description || '';
+        descriptionEl.hidden = !hotel.description;
+      }
+
+      addressEl.textContent = '';
+      if (hotel.address) {
+        const strong = document.createElement('strong');
+        strong.textContent = 'Address:';
+        addressEl.appendChild(strong);
+        addressEl.appendChild(document.createTextNode(` ${hotel.address} `));
+        if (mapLink) {
+          const mapAnchor = document.createElement('a');
+          mapAnchor.href = mapLink;
+          mapAnchor.textContent = 'Open in Maps';
+          mapAnchor.className = 'inline-link';
+          mapAnchor.target = '_blank';
+          mapAnchor.rel = 'noopener noreferrer';
+          mapAnchor.setAttribute('aria-label', `Open ${hotel.name} in Google Maps`);
+          addressEl.appendChild(mapAnchor);
+        }
+      } else {
+        addressEl.textContent = 'Address not available.';
+      }
+
+      phoneEl.textContent = '';
+      if (hotel.phone) {
+        const strong = document.createElement('strong');
+        strong.textContent = 'Phone:';
+        phoneEl.appendChild(strong);
+        phoneEl.appendChild(document.createTextNode(` ${hotel.phone}`));
+      } else {
+        phoneEl.textContent = 'Phone not available.';
+      }
+
+      stayEl.textContent = '';
+      if (hotel.checkIn || hotel.checkOut) {
+        const strong = document.createElement('strong');
+        strong.textContent = 'Stay info:';
+        stayEl.appendChild(strong);
+        const parts = [];
+        if (hotel.checkIn) parts.push(`Check-in: ${hotel.checkIn}`);
+        if (hotel.checkOut) parts.push(`Check-out: ${hotel.checkOut}`);
+        stayEl.appendChild(document.createTextNode(` ${parts.join(' • ')}`));
+        stayEl.hidden = false;
+      } else {
+        stayEl.hidden = true;
+      }
+
+      actionsEl.innerHTML = '';
+      if (phoneDigits) {
+        actionsEl.appendChild(
+          createActionButton({
+            href: `tel:${phoneDigits}`,
+            text: 'Call',
+            ariaLabel: `Call ${hotel.name}`,
+          })
+        );
+      }
+
+      if (mapLink) {
+        actionsEl.appendChild(
+          createActionButton({
+            href: mapLink,
+            text: 'Map',
+            ariaLabel: `Open ${hotel.name} in Google Maps`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          })
+        );
+      }
+
+      if (hotel.website) {
+        actionsEl.appendChild(
+          createActionButton({
+            href: hotel.website,
+            text: 'Website',
+            ariaLabel: `Open website for ${hotel.name}`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          })
+        );
+      }
+
+      const qrTarget = new URL(`hotel.html?id=${encodeURIComponent(slug)}`, window.location.href).toString();
+      qrImage.src = `https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=${encodeForURL(qrTarget)}`;
+      qrImage.alt = `QR code linking to details for ${hotel.name}`;
+    };
+
+    const fetchHotels = async () => {
+      const response = await fetch('hotels.json');
+      if (!response.ok) {
+        throw new Error('Unable to load hotels list.');
+      }
+      return response.json();
+    };
+
+    const init = async () => {
+      if (!slugParam) {
+        showNotFound();
+        return;
+      }
+
+      try {
+        const hotels = await fetchHotels();
+        const hotelsWithSlugs = hotels.map((hotel) => ({
+          ...hotel,
+          slug: hotel.slug ? hotel.slug : slugify(hotel.name || ''),
+        }));
+        const normalizedSlug = slugParam.trim().toLowerCase();
+        const match = hotelsWithSlugs.find((hotel) => (hotel.slug || '').toLowerCase() === normalizedSlug);
+
+        if (!match) {
+          showNotFound();
+          return;
+        }
+
+        renderHotel(match, match.slug);
+      } catch (error) {
+        console.error(error);
+        showMessage('Unable to load hotel details. Please try again later.');
+      }
+    };
+
+    init();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -125,13 +125,28 @@
       box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
       display: flex;
-      justify-content: space-between;
-      gap: 1.5rem;
+      flex-direction: column;
+      gap: 1rem;
     }
 
     .hotel-card:hover {
       transform: translateY(-4px);
       box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+    }
+
+    .hotel-card-main {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1.5rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .hotel-card-main:focus-visible {
+      outline: 3px solid #4f46e5;
+      outline-offset: 4px;
+      border-radius: 12px;
     }
 
     .hotel-details {
@@ -186,6 +201,33 @@
       box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
     }
 
+    .hotel-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .action-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.55rem 0.9rem;
+      border-radius: 999px;
+      background: #4f46e5;
+      color: #fff;
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 600;
+      min-height: 44px;
+      min-width: 88px;
+      transition: background 0.2s ease;
+    }
+
+    .action-button:hover,
+    .action-button:focus {
+      background: #4338ca;
+    }
+
     .tag-list {
       display: flex;
       flex-wrap: wrap;
@@ -228,11 +270,18 @@
       .hotel-card,
       .resource-card {
         padding: 1.2rem;
+      }
+
+      .hotel-card-main {
         flex-direction: column;
-        align-items: flex-start;
       }
 
       .hotel-qr {
+        width: 100%;
+        justify-content: flex-start;
+      }
+
+      .hotel-actions {
         width: 100%;
         justify-content: flex-start;
       }
@@ -325,20 +374,72 @@
     const resultsContainer = document.getElementById('results');
     const resultsMeta = document.getElementById('results-meta');
 
-    function createLink({ href, text }) {
+    function slugify(value = '') {
+      return value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    }
+
+    function onlyDigits(value = '') {
+      return String(value || '').replace(/\D+/g, '');
+    }
+
+    function encodeForURL(value = '') {
+      return encodeURIComponent(String(value ?? ''));
+    }
+
+    function createLink({
+      href,
+      text,
+      className = 'hotel-link',
+      target = '_blank',
+      rel = 'noopener noreferrer',
+    }) {
       const link = document.createElement('a');
-      link.className = 'hotel-link';
+      link.className = className;
       link.href = href;
       link.textContent = text;
-      link.target = '_blank';
-      link.rel = 'noopener noreferrer';
+      if (target) {
+        link.target = target;
+      }
+      if (rel) {
+        link.rel = rel;
+      }
       return link;
+    }
+
+    function createActionButton({ href, text, ariaLabel, target, rel }) {
+      const button = document.createElement('a');
+      button.className = 'action-button';
+      button.href = href;
+      button.textContent = text;
+      if (ariaLabel) {
+        button.setAttribute('aria-label', ariaLabel);
+      }
+      if (target) {
+        button.target = target;
+      }
+      if (rel) {
+        button.rel = rel;
+      }
+      return button;
     }
 
     function renderHotels(hotels) {
       hotels.forEach((hotel) => {
+        const slug = hotel.slug || slugify(hotel.name || '');
+        const encodedSlug = encodeURIComponent(slug);
+        const detailPath = `hotel.html?id=${encodedSlug}`;
+        const absoluteDetailUrl = new URL(detailPath, window.location.href).toString();
+
         const card = document.createElement('article');
         card.className = 'hotel-card';
+
+        const mainLink = document.createElement('a');
+        mainLink.className = 'hotel-card-main';
+        mainLink.href = detailPath;
+        mainLink.setAttribute('aria-label', `View details for ${hotel.name}`);
 
         const details = document.createElement('div');
         details.className = 'hotel-details';
@@ -347,15 +448,19 @@
         name.textContent = hotel.name;
         details.appendChild(name);
 
-        const address = document.createElement('p');
-        address.className = 'hotel-meta';
-        address.innerHTML = `<strong>Address:</strong> ${hotel.address}`;
-        details.appendChild(address);
+        if (hotel.address) {
+          const address = document.createElement('p');
+          address.className = 'hotel-meta';
+          address.innerHTML = `<strong>Address:</strong> ${hotel.address}`;
+          details.appendChild(address);
+        }
 
-        const phone = document.createElement('p');
-        phone.className = 'hotel-meta';
-        phone.innerHTML = `<strong>Phone:</strong> ${hotel.phone}`;
-        details.appendChild(phone);
+        if (hotel.phone) {
+          const phone = document.createElement('p');
+          phone.className = 'hotel-meta';
+          phone.innerHTML = `<strong>Phone:</strong> ${hotel.phone}`;
+          details.appendChild(phone);
+        }
 
         if (hotel.checkIn || hotel.checkOut) {
           const stayDetails = document.createElement('p');
@@ -367,23 +472,68 @@
           details.appendChild(stayDetails);
         }
 
-        if (hotel.website) {
-          details.appendChild(createLink({ href: hotel.website, text: 'Visit Website' }));
-        }
+        mainLink.appendChild(details);
 
         const qrWrapper = document.createElement('div');
         qrWrapper.className = 'hotel-qr';
 
         const qrImage = document.createElement('img');
-        const encodedWebsite = encodeURIComponent(hotel.website || hotel.mapLink || '');
-        qrImage.src = `https://chart.googleapis.com/chart?cht=qr&chs=100x100&chl=${encodedWebsite}`;
+        qrImage.src = `https://chart.googleapis.com/chart?cht=qr&chs=100x100&chl=${encodeForURL(
+          absoluteDetailUrl
+        )}`;
         qrImage.alt = `QR code for ${hotel.name}`;
         qrImage.width = 100;
         qrImage.height = 100;
         qrWrapper.appendChild(qrImage);
 
-        card.appendChild(details);
-        card.appendChild(qrWrapper);
+        mainLink.appendChild(qrWrapper);
+
+        card.appendChild(mainLink);
+
+        const actions = document.createElement('div');
+        actions.className = 'hotel-actions';
+
+        const phoneDigits = onlyDigits(hotel.phone || '');
+        if (phoneDigits) {
+          actions.appendChild(
+            createActionButton({
+              href: `tel:${phoneDigits}`,
+              text: 'Call',
+              ariaLabel: `Call ${hotel.name}`,
+            })
+          );
+        }
+
+        if (hotel.address) {
+          const mapLink = `https://www.google.com/maps/search/?api=1&query=${encodeForURL(
+            hotel.address
+          )}`;
+          actions.appendChild(
+            createActionButton({
+              href: mapLink,
+              text: 'Map',
+              ariaLabel: `Open ${hotel.name} in Google Maps`,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            })
+          );
+        }
+
+        if (hotel.website) {
+          actions.appendChild(
+            createActionButton({
+              href: hotel.website,
+              text: 'Website',
+              ariaLabel: `Open website for ${hotel.name}`,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            })
+          );
+        }
+
+        if (actions.children.length) {
+          card.appendChild(actions);
+        }
 
         resultsContainer.appendChild(card);
       });
@@ -432,8 +582,11 @@
         }
 
         if (listing.website) {
-          const link = createLink({ href: listing.website, text: 'View Details' });
-          link.className = 'resource-link';
+          const link = createLink({
+            href: listing.website,
+            text: 'View Details',
+            className: 'resource-link',
+          });
           card.appendChild(link);
         }
 
@@ -491,8 +644,11 @@
         }
 
         if (resource.website) {
-          const link = createLink({ href: resource.website, text: 'Visit website' });
-          link.className = 'resource-link';
+          const link = createLink({
+            href: resource.website,
+            text: 'Visit website',
+            className: 'resource-link',
+          });
           card.appendChild(link);
         }
 
@@ -526,6 +682,7 @@
               item.description,
               item.notes,
               item.contact,
+              item.slug,
             ]
               .filter(Boolean)
               .join(' ')
@@ -568,7 +725,10 @@
           fetchJson('housing.json'),
           fetchJson('resources.json'),
         ]);
-        state.data.hotels = hotels;
+        state.data.hotels = hotels.map((hotel) => ({
+          ...hotel,
+          slug: hotel.slug ? hotel.slug : slugify(hotel.name || ''),
+        }));
         state.data.housing = housing;
         state.data.resources = resources;
         renderActiveTab();


### PR DESCRIPTION
## Summary
- add a dedicated `hotel.html` detail view that loads hotels by slug, exposes map/call/website deep links, and renders a self-referencing QR code
- update the index listing to generate slugs, link each hotel card to its detail page, expose call/map buttons, and retarget QR codes to the new deep links
- enhance the admin panel to preview and copy a recommended slug while reminding contributors to sync updates back to `hotels.json`

## Testing
- Manual QA: opened `hotel.html?id=dells-inn` in a local browser session

------
https://chatgpt.com/codex/tasks/task_e_68e0ab8d04608333b5b52f8af4848275