### PR TITLE
chore: repo inventory, guardrails, i18n helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,8 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Allow shared front-end libraries
+!js/
+!js/lib/
+!js/lib/i18n.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing Guidelines
+
+## Code Style
+- Use modern ES modules with `import`/`export` syntax.
+- Avoid frameworks; stick to vanilla JavaScript and browser APIs.
+- Build HTML fragments with template strings and inject them via the DOM APIs.
+
+## Accessibility
+- Prefer semantic HTML elements for structure and meaning.
+- Provide descriptive `aria-label` or `aria-labelledby` attributes where needed.
+- Ensure all interactive elements have visible focus states.
+
+## Internationalization (i18n)
+- Route all user-facing strings through the shared `t(key, vars?)` helper.
+- Define translations per language in `/translations/{lang}.json` files.
+- Keep translation keys descriptive and consistent across pages.
+
+## Performance
+- Lazy-load large datasets or modules when they are first needed.
+- Use the service worker with a stale-while-revalidate strategy for remote assets and JSON data.
+- Audit bundle size and network requests before shipping new features.
+
+## Security & Privacy
+- Do not collect or store personally identifiable information (PII) unless absolutely required.
+- Request explicit consent before accessing geolocation or other sensitive APIs.
+- Communicate clearly to users who can view any submitted information.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,13 @@
+# Product Backlog
+
+## Sprint Now
+- _TBD_
+
+## Next
+- _TBD_
+
+## Later
+- _TBD_
+
+## Decisions
+- _TBD_

--- a/js/lib/i18n.js
+++ b/js/lib/i18n.js
@@ -1,0 +1,61 @@
+const translationsCache = new Map();
+const defaultLang = 'en';
+
+async function loadTranslations(lang) {
+  if (translationsCache.has(lang)) {
+    return translationsCache.get(lang);
+  }
+
+  const loader = (async () => {
+    const response = await fetch(`/translations/${lang}.json`, { cache: 'no-cache' });
+    if (!response.ok) {
+      throw new Error(`Failed to load translations for "${lang}"`);
+    }
+    return response.json();
+  })();
+
+  translationsCache.set(lang, loader);
+  return loader;
+}
+
+function resolveKey(translations, key) {
+  return key.split('.').reduce((acc, part) => (acc && acc[part] !== undefined ? acc[part] : undefined), translations);
+}
+
+function formatTemplate(template, vars) {
+  if (typeof template !== 'string') {
+    return template;
+  }
+
+  return template.replace(/\{(\w+)\}/g, (_, varKey) => {
+    return Object.prototype.hasOwnProperty.call(vars, varKey) ? vars[varKey] : `{${varKey}}`;
+  });
+}
+
+export async function t(key, vars = {}) {
+  const lang = localStorage.getItem('lang') || defaultLang;
+
+  try {
+    const translations = await loadTranslations(lang);
+    const value = resolveKey(translations, key);
+    if (value !== undefined) {
+      return formatTemplate(value, vars);
+    }
+  } catch (error) {
+    if (lang !== defaultLang) {
+      console.warn(error);
+    } else {
+      console.warn(`i18n: ${error.message}`);
+    }
+  }
+
+  if (lang !== defaultLang) {
+    const fallbackTranslations = await loadTranslations(defaultLang);
+    const fallbackValue = resolveKey(fallbackTranslations, key);
+    if (fallbackValue !== undefined) {
+      return formatTemplate(fallbackValue, vars);
+    }
+  }
+
+  return formatTemplate(key, vars);
+}


### PR DESCRIPTION
## Summary
- add contributing guardrails covering code style, accessibility, i18n, performance, and privacy
- create docs backlog skeleton with Sprint Now/Next/Later/Decisions buckets
- add cached translation helper module and update gitignore to allow shared JS libs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e76066b92c83338de2a7cef142c80a