### PR TITLE
feat: onboarding deep-link with week 1 checklist

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1,0 +1,41 @@
+:root {
+  --theme-background: #f5f7fa;
+  --theme-text: #1f2933;
+  --theme-header-text: #ffffff;
+  --theme-primary: #4f46e5;
+  --theme-primary-dark: #4338ca;
+  --theme-gradient-start: #4f46e5;
+  --theme-gradient-end: #7c3aed;
+  --theme-focus-ring: rgba(129, 140, 248, 0.45);
+  --theme-focus-ring-outline: rgba(129, 140, 248, 0.55);
+  --theme-card-title: #312e81;
+  --theme-chip-bg: rgba(255, 255, 255, 0.25);
+  --theme-chip-hover: rgba(79, 70, 229, 0.35);
+  --theme-chip-text: #eef2ff;
+  --theme-tag-bg: rgba(79, 70, 229, 0.12);
+  --theme-tag-text: #4c1d95;
+  --theme-modal-bg: #ffffff;
+}
+
+body.theme-KAL {
+  --theme-background: #f0fdfa;
+  --theme-text: #0f172a;
+  --theme-header-text: #ecfeff;
+  --theme-primary: #0f766e;
+  --theme-primary-dark: #0d9488;
+  --theme-gradient-start: #0f766e;
+  --theme-gradient-end: #14b8a6;
+  --theme-focus-ring: rgba(13, 148, 136, 0.35);
+  --theme-focus-ring-outline: rgba(15, 118, 110, 0.45);
+  --theme-card-title: #0f766e;
+  --theme-chip-bg: rgba(20, 184, 166, 0.2);
+  --theme-chip-hover: rgba(13, 148, 136, 0.35);
+  --theme-chip-text: #ecfeff;
+  --theme-tag-bg: rgba(45, 212, 191, 0.18);
+  --theme-tag-text: #0f766e;
+  --theme-modal-bg: #ffffff;
+}
+
+body.theme-DEFAULT {
+  /* Ensures we can explicitly reset to defaults if needed */
+}

--- a/data/onboarding.DEFAULT.json
+++ b/data/onboarding.DEFAULT.json
@@ -1,0 +1,16 @@
+{
+  "property": "DEFAULT",
+  "title": "Orientation — Week 1",
+  "tasks": [
+    {"id": "welcome", "label": "Pick up welcome packet", "est_min": 5},
+    {"id": "hr", "label": "Complete HR I-9 + W-4", "est_min": 20},
+    {"id": "bank", "label": "Open bank account", "est_min": 30},
+    {"id": "sim", "label": "Get SIM card", "est_min": 15},
+    {"id": "bus", "label": "Get bus pass", "est_min": 10},
+    {"id": "clinic", "label": "Save clinic contacts", "est_min": 5},
+    {"id": "safety", "label": "Enable SafeWalk SOS", "est_min": 2},
+    {"id": "events", "label": "RSVP one event", "est_min": 2},
+    {"id": "locker", "label": "Add docs to locker", "est_min": 5},
+    {"id": "tour", "label": "Watch quick tour", "est_min": 3}
+  ]
+}

--- a/data/onboarding.KAL.json
+++ b/data/onboarding.KAL.json
@@ -1,0 +1,16 @@
+{
+  "property": "KAL",
+  "title": "Orientation — Week 1",
+  "tasks": [
+    {"id": "welcome", "label": "Pick up welcome packet", "est_min": 5},
+    {"id": "hr", "label": "Complete HR I-9 + W-4", "est_min": 20},
+    {"id": "bank", "label": "Open bank account", "est_min": 30},
+    {"id": "sim", "label": "Get SIM card", "est_min": 15},
+    {"id": "bus", "label": "Get bus pass", "est_min": 10},
+    {"id": "clinic", "label": "Save clinic contacts", "est_min": 5},
+    {"id": "safety", "label": "Enable SafeWalk SOS", "est_min": 2},
+    {"id": "events", "label": "RSVP one event", "est_min": 2},
+    {"id": "locker", "label": "Add docs to locker", "est_min": 5},
+    {"id": "tour", "label": "Watch quick tour", "est_min": 3}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#007BFF">
+  <link rel="stylesheet" href="css/theme.css">
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('service-worker.js');
@@ -16,15 +17,15 @@
       margin: 0;
       padding: 0;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #f5f7fa;
-      color: #1f2933;
+      background: var(--theme-background);
+      color: var(--theme-text);
     }
 
     header {
       text-align: center;
       padding: 2rem 1rem 1rem;
-      background: linear-gradient(135deg, #4f46e5, #7c3aed);
-      color: #fff;
+      background: linear-gradient(135deg, var(--theme-gradient-start), var(--theme-gradient-end));
+      color: var(--theme-header-text);
       box-shadow: 0 4px 10px rgba(79, 70, 229, 0.3);
       border-bottom-left-radius: 18px;
       border-bottom-right-radius: 18px;
@@ -55,15 +56,15 @@
     }
 
     .search-container input[type='search']:focus {
-      box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.45),
+      box-shadow: 0 0 0 3px var(--theme-focus-ring),
         0 12px 20px rgba(15, 23, 42, 0.18);
     }
 
     .filter-chip {
       border: none;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.25);
-      color: #eef2ff;
+      background: var(--theme-chip-bg);
+      color: var(--theme-chip-text);
       font-weight: 600;
       padding: 0.45rem 1rem;
       cursor: pointer;
@@ -94,24 +95,24 @@
 
     .language-toggle button:hover,
     .language-toggle button:focus {
-      background: rgba(79, 70, 229, 0.35);
+      background: var(--theme-chip-hover);
       transform: translateY(-1px);
     }
 
     .language-toggle button.is-active {
-      background: #4338ca;
+      background: var(--theme-primary-dark);
       color: #fff;
     }
 
     .filter-chip:hover,
     .filter-chip:focus {
-      background: rgba(255, 255, 255, 0.35);
+      background: var(--theme-chip-hover);
       transform: translateY(-1px);
     }
 
     .filter-chip.is-active {
-      background: #4338ca;
-      color: #fff;
+      background: var(--theme-primary-dark);
+      color: var(--theme-header-text);
     }
 
     .tablist {
@@ -147,7 +148,7 @@
       justify-content: space-between;
       gap: 1rem;
       margin-bottom: 1rem;
-      color: #4338ca;
+      color: var(--theme-primary-dark);
       font-weight: 600;
     }
 
@@ -184,7 +185,7 @@
     }
 
     .hotel-card-main:focus-visible {
-      outline: 3px solid #4f46e5;
+      outline: 3px solid var(--theme-primary);
       outline-offset: 4px;
       border-radius: 12px;
     }
@@ -197,7 +198,7 @@
     .resource-card h2 {
       margin: 0 0 0.5rem;
       font-size: 1.3rem;
-      color: #312e81;
+      color: var(--theme-card-title);
     }
 
     .hotel-meta,
@@ -212,8 +213,8 @@
       display: inline-block;
       margin-top: 0.8rem;
       padding: 0.55rem 0.9rem;
-      background: #4f46e5;
-      color: #fff;
+      background: var(--theme-primary);
+      color: var(--theme-header-text);
       text-decoration: none;
       border-radius: 999px;
       font-size: 0.9rem;
@@ -225,7 +226,7 @@
     a.hotel-link:focus,
     a.resource-link:hover,
     a.resource-link:focus {
-      background: #4338ca;
+      background: var(--theme-primary-dark);
     }
 
     .hotel-qr {
@@ -253,8 +254,8 @@
       justify-content: center;
       padding: 0.55rem 0.9rem;
       border-radius: 999px;
-      background: #4f46e5;
-      color: #fff;
+      background: var(--theme-primary);
+      color: var(--theme-header-text);
       text-decoration: none;
       font-size: 0.9rem;
       font-weight: 600;
@@ -265,7 +266,7 @@
 
     .action-button:hover,
     .action-button:focus {
-      background: #4338ca;
+      background: var(--theme-primary-dark);
     }
 
     .tag-list {
@@ -276,12 +277,177 @@
     }
 
     .tag {
-      background: rgba(79, 70, 229, 0.12);
-      color: #4c1d95;
+      background: var(--theme-tag-bg);
+      color: var(--theme-tag-text);
       padding: 0.25rem 0.6rem;
       border-radius: 999px;
       font-size: 0.75rem;
       font-weight: 600;
+    }
+
+    .resume-orientation {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 1.5rem auto 0;
+      padding: 0.75rem 1.5rem;
+      border-radius: 999px;
+      border: none;
+      background: var(--theme-primary);
+      color: var(--theme-header-text);
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+      box-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
+    }
+
+    .resume-orientation:hover,
+    .resume-orientation:focus {
+      background: var(--theme-primary-dark);
+      transform: translateY(-1px);
+    }
+
+    .resume-orientation:focus-visible {
+      outline: 3px solid var(--theme-focus-ring-outline);
+      outline-offset: 4px;
+    }
+
+    .onboarding-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 999;
+    }
+
+    .onboarding-backdrop[hidden] {
+      display: none;
+    }
+
+    .onboarding-modal {
+      background: var(--theme-modal-bg);
+      color: var(--theme-text);
+      border-radius: 18px;
+      width: min(520px, 100%);
+      max-height: 90vh;
+      overflow: hidden;
+      box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .onboarding-modal header {
+      background: linear-gradient(135deg, var(--theme-gradient-start), var(--theme-gradient-end));
+      color: var(--theme-header-text);
+      padding: 1.5rem 1.5rem 1rem;
+      text-align: left;
+      border-radius: 18px 18px 0 0;
+      box-shadow: none;
+    }
+
+    .onboarding-modal header h2 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .onboarding-modal header p {
+      margin: 0.5rem 0 0;
+      font-weight: 500;
+    }
+
+    .onboarding-modal main {
+      padding: 1.5rem;
+      overflow-y: auto;
+    }
+
+    .onboarding-modal footer {
+      padding: 1rem 1.5rem 1.5rem;
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+    }
+
+    .onboarding-progress {
+      font-weight: 600;
+      color: var(--theme-primary-dark);
+      margin-bottom: 1rem;
+    }
+
+    .onboarding-task-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .onboarding-task {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      padding: 1rem;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.8);
+      box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+    }
+
+    .onboarding-task-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .onboarding-task label {
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .onboarding-task small {
+      color: var(--theme-primary);
+      font-weight: 600;
+    }
+
+    .onboarding-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .onboarding-actions a {
+      text-decoration: none;
+      background: var(--theme-primary);
+      color: var(--theme-header-text);
+      padding: 0.4rem 0.8rem;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.85rem;
+      transition: background 0.2s ease;
+    }
+
+    .onboarding-actions a:hover,
+    .onboarding-actions a:focus {
+      background: var(--theme-primary-dark);
+    }
+
+    .onboarding-close {
+      border: none;
+      border-radius: 999px;
+      padding: 0.6rem 1rem;
+      font-weight: 600;
+      background: var(--theme-chip-bg);
+      color: var(--theme-text);
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    .onboarding-close:hover,
+    .onboarding-close:focus {
+      background: var(--theme-chip-hover);
     }
 
     @media (max-width: 600px) {
@@ -329,6 +495,65 @@
   </style>
 </head>
 <body>
+  <script>
+    (function () {
+      const router = (window.__J1Router = {});
+      const params = new URLSearchParams(window.location.search);
+      const propParam = (params.get('prop') || '').trim();
+      const langParam = (params.get('lang') || '').trim();
+
+      function applyThemeClass(propertyCode) {
+        if (!propertyCode || !document.body) {
+          return;
+        }
+        const existing = Array.from(document.body.classList);
+        existing.forEach((className) => {
+          if (/^theme-/i.test(className)) {
+            document.body.classList.remove(className);
+          }
+        });
+        document.body.classList.add(`theme-${propertyCode}`);
+      }
+
+      let normalizedProp = null;
+      try {
+        if (propParam) {
+          normalizedProp = propParam.toUpperCase();
+          localStorage.setItem('prop', normalizedProp);
+          router.propFromUrl = normalizedProp;
+        } else {
+          const storedProp = localStorage.getItem('prop');
+          normalizedProp = storedProp ? storedProp.toUpperCase() : null;
+        }
+      } catch (error) {
+        normalizedProp = propParam ? propParam.trim().toUpperCase() : null;
+      }
+
+      if (normalizedProp) {
+        applyThemeClass(normalizedProp);
+      }
+
+      let normalizedLang = null;
+      try {
+        if (langParam) {
+          normalizedLang = langParam.toLowerCase();
+          localStorage.setItem('lang', normalizedLang);
+          localStorage.setItem('preferredLanguage', normalizedLang);
+          router.langFromUrl = normalizedLang;
+        } else {
+          const storedLang =
+            localStorage.getItem('preferredLanguage') || localStorage.getItem('lang');
+          normalizedLang = storedLang ? storedLang.toLowerCase() : null;
+        }
+      } catch (error) {
+        normalizedLang = langParam ? langParam.trim().toLowerCase() : null;
+      }
+
+      if (normalizedLang) {
+        document.documentElement.setAttribute('lang', normalizedLang);
+      }
+    })();
+  </script>
   <header>
     <h1 data-i18n="app.title">🏨 Wisconsin Dells Experience Hub</h1>
     <div
@@ -409,6 +634,9 @@
     </nav>
   </header>
   <main>
+    <button type="button" class="resume-orientation" id="resume-orientation" data-i18n="onboarding.resume">
+      Resume Orientation
+    </button>
     <div class="results-meta" id="results-meta" aria-live="polite"></div>
     <section
       id="results"
@@ -457,6 +685,8 @@
       currentLanguage: 'en',
       supported: ['en', 'es', 'pt'],
     };
+    const hub = (window.J1Hub = window.J1Hub || {});
+    const languageListeners = new Set();
 
     function formatTemplate(template, replacements = {}) {
       let result = template;
@@ -479,6 +709,28 @@
         }
       }
       return formatTemplate(key, replacements);
+    }
+
+    hub.translate = (key, replacements = {}) => translate(key, replacements);
+    hub.getCurrentLanguage = () => i18n.currentLanguage;
+    hub.getTranslations = () => ({ ...i18n.translations });
+    hub.onLanguageChange = function (callback) {
+      if (typeof callback !== 'function') {
+        return () => {};
+      }
+      languageListeners.add(callback);
+      callback(i18n.currentLanguage);
+      return () => languageListeners.delete(callback);
+    };
+
+    function notifyLanguageChange(language) {
+      languageListeners.forEach((listener) => {
+        try {
+          listener(language);
+        } catch (error) {
+          console.error('Language listener failed', error);
+        }
+      });
     }
 
     function updateLanguageToggle(activeLanguage) {
@@ -550,6 +802,7 @@
       updateLanguageToggle(normalized);
       updateStaticText();
       renderActiveTab(searchInput ? searchInput.value : '');
+      notifyLanguageChange(normalized);
     }
 
     function slugify(value = '') {
@@ -884,7 +1137,7 @@
         const messageKey = tab?.emptyKey || 'messages.no_results';
         const emptyMessage = translate(messageKey);
         const messageElement = document.createElement('p');
-        messageElement.style.color = '#4f46e5';
+        messageElement.style.color = 'var(--theme-primary)';
         messageElement.style.fontWeight = '600';
         messageElement.textContent = emptyMessage;
         resultsContainer.appendChild(messageElement);
@@ -1000,5 +1253,6 @@
 
     initialize();
   </script>
+  <script type="module" src="js/onboarding.js"></script>
 </body>
 </html>

--- a/js/onboarding.js
+++ b/js/onboarding.js
@@ -1,0 +1,488 @@
+const hub = (window.J1Hub = window.J1Hub || {});
+const router = window.__J1Router || {};
+
+const FALLBACK_TRANSLATIONS = {
+  'onboarding.resume': 'Resume Orientation',
+  'onboarding.title': 'Orientation — Week 1',
+  'onboarding.progress': '{completed} of {total} completed',
+  'onboarding.add_to_calendar': 'Add to Calendar',
+  'onboarding.estimate': '≈ {minutes} min',
+  'onboarding.close': 'Close',
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1")]';
+
+let resumeButtonEl;
+let backdropEl;
+let modalEl;
+let titleEl;
+let progressEl;
+let taskListEl;
+let closeButtonEl;
+let checklistData = null;
+let completedTasks = new Set();
+let taskNodeRegistry = new Map();
+let propertyCode = 'DEFAULT';
+let shouldAutoOpen = false;
+let autoOpenHandled = false;
+let previousFocus = null;
+let isModalOpen = false;
+
+function translate(key, replacements = {}) {
+  if (typeof hub.translate === 'function') {
+    const translated = hub.translate(key, replacements);
+    if (translated && translated !== key) {
+      return translated;
+    }
+  }
+  const fallback = FALLBACK_TRANSLATIONS[key];
+  if (!fallback) {
+    return key;
+  }
+  return fallback.replace(/\{(\w+)\}/g, (_, token) => {
+    return Object.prototype.hasOwnProperty.call(replacements, token)
+      ? replacements[token]
+      : `{${token}}`;
+  });
+}
+
+function getStoredProperty() {
+  if (router.propFromUrl) {
+    return router.propFromUrl;
+  }
+  try {
+    const stored = localStorage.getItem('prop');
+    if (stored) {
+      return stored.toUpperCase();
+    }
+  } catch (error) {
+    // Ignore storage errors
+  }
+  return 'DEFAULT';
+}
+
+function getCompletedKey() {
+  return `onboarding.${propertyCode}.completed`;
+}
+
+function getSeenKey() {
+  return `onboarding.${propertyCode}.seen`;
+}
+
+function loadCompletedTasks() {
+  try {
+    const raw = localStorage.getItem(getCompletedKey());
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('Unable to parse onboarding progress', error);
+  }
+  return [];
+}
+
+function persistCompletedTasks() {
+  try {
+    const serialized = JSON.stringify(Array.from(completedTasks));
+    localStorage.setItem(getCompletedKey(), serialized);
+  } catch (error) {
+    console.warn('Unable to persist onboarding progress', error);
+  }
+}
+
+function hasSeenChecklist() {
+  try {
+    return localStorage.getItem(getSeenKey()) === 'true';
+  } catch (error) {
+    return false;
+  }
+}
+
+function markChecklistSeen() {
+  try {
+    localStorage.setItem(getSeenKey(), 'true');
+  } catch (error) {
+    // ignore
+  }
+}
+
+function formatIcsDate(date) {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function escapeIcsText(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+}
+
+function buildIcsDataUrl(task) {
+  const now = new Date();
+  const startDate = new Date(now.getTime() + 5 * 60 * 1000);
+  const durationMinutes = Number.isFinite(task.est_min) ? Number(task.est_min) : 15;
+  const endDate = new Date(startDate.getTime() + Math.max(durationMinutes, 1) * 60 * 1000);
+  const dtStamp = formatIcsDate(now);
+  const dtStart = formatIcsDate(startDate);
+  const dtEnd = formatIcsDate(endDate);
+  const summary = escapeIcsText(`J1Hub: ${task.label}`);
+  const description = escapeIcsText(checklistData?.title || translate('onboarding.title'));
+  const uid = `${task.id}-${propertyCode}-${startDate.getTime()}@j1hub.local`;
+  const icsContent = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//J1Hub//Onboarding//EN',
+    'CALSCALE:GREGORIAN',
+    'BEGIN:VEVENT',
+    `DTSTAMP:${dtStamp}`,
+    `DTSTART:${dtStart}`,
+    `DTEND:${dtEnd}`,
+    `SUMMARY:${summary}`,
+    `DESCRIPTION:${description}`,
+    `UID:${uid}`,
+    'STATUS:CONFIRMED',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+  return `data:text/calendar;charset=utf-8,${encodeURIComponent(icsContent)}`;
+}
+
+function updateProgressText() {
+  if (!progressEl || !checklistData) {
+    return;
+  }
+  const total = Array.isArray(checklistData.tasks) ? checklistData.tasks.length : 0;
+  const completedCount = completedTasks.size;
+  progressEl.textContent = translate('onboarding.progress', {
+    completed: completedCount,
+    total,
+  });
+}
+
+function updateTaskTranslations() {
+  taskNodeRegistry.forEach((node) => {
+    if (node.estimateEl) {
+      node.estimateEl.textContent = translate('onboarding.estimate', {
+        minutes: node.task.est_min ?? 15,
+      });
+    }
+    if (node.calendarLink) {
+      node.calendarLink.textContent = translate('onboarding.add_to_calendar');
+      node.calendarLink.setAttribute(
+        'aria-label',
+        `${translate('onboarding.add_to_calendar')} – ${node.task.label}`
+      );
+    }
+  });
+}
+
+function applyTranslations() {
+  if (resumeButtonEl) {
+    resumeButtonEl.textContent = translate('onboarding.resume');
+  }
+  if (closeButtonEl) {
+    closeButtonEl.textContent = translate('onboarding.close');
+  }
+  if (titleEl) {
+    const translatedTitle = translate('onboarding.title');
+    titleEl.textContent = translatedTitle && translatedTitle !== 'onboarding.title'
+      ? translatedTitle
+      : checklistData?.title || FALLBACK_TRANSLATIONS['onboarding.title'];
+  }
+  updateProgressText();
+  updateTaskTranslations();
+}
+
+function renderTasks() {
+  if (!taskListEl || !checklistData) {
+    return;
+  }
+  taskNodeRegistry.clear();
+  taskListEl.innerHTML = '';
+  const tasks = Array.isArray(checklistData.tasks) ? checklistData.tasks : [];
+  tasks.forEach((task) => {
+    const listItem = document.createElement('li');
+    listItem.className = 'onboarding-task';
+    listItem.dataset.taskId = task.id;
+
+    const header = document.createElement('div');
+    header.className = 'onboarding-task-header';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    const checkboxId = `onboarding-${task.id}`;
+    checkbox.id = checkboxId;
+    checkbox.checked = completedTasks.has(task.id);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        completedTasks.add(task.id);
+      } else {
+        completedTasks.delete(task.id);
+      }
+      persistCompletedTasks();
+      updateProgressText();
+    });
+
+    const label = document.createElement('label');
+    label.setAttribute('for', checkboxId);
+    label.textContent = task.label;
+
+    const estimate = document.createElement('small');
+    estimate.textContent = translate('onboarding.estimate', {
+      minutes: task.est_min ?? 15,
+    });
+
+    header.appendChild(checkbox);
+    header.appendChild(label);
+    header.appendChild(estimate);
+
+    const actions = document.createElement('div');
+    actions.className = 'onboarding-actions';
+
+    const calendarLink = document.createElement('a');
+    calendarLink.href = buildIcsDataUrl(task);
+    calendarLink.download = `J1Hub-${task.id}.ics`;
+    calendarLink.textContent = translate('onboarding.add_to_calendar');
+    calendarLink.setAttribute(
+      'aria-label',
+      `${translate('onboarding.add_to_calendar')} – ${task.label}`
+    );
+    calendarLink.addEventListener('click', () => {
+      calendarLink.href = buildIcsDataUrl(task);
+    });
+
+    actions.appendChild(calendarLink);
+
+    listItem.appendChild(header);
+    listItem.appendChild(actions);
+    taskListEl.appendChild(listItem);
+
+    taskNodeRegistry.set(task.id, {
+      task,
+      estimateEl: estimate,
+      calendarLink,
+    });
+  });
+  updateProgressText();
+}
+
+function getFocusableElements() {
+  if (!modalEl) {
+    return [];
+  }
+  return Array.from(modalEl.querySelectorAll(FOCUSABLE_SELECTOR)).filter((element) => {
+    return !(element instanceof HTMLElement) || !element.hasAttribute('disabled');
+  });
+}
+
+function handleKeyDown(event) {
+  if (!isModalOpen) {
+    return;
+  }
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeModal();
+    return;
+  }
+  if (event.key === 'Tab') {
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      modalEl.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+}
+
+function openModal() {
+  if (!checklistData || !backdropEl || !modalEl || isModalOpen) {
+    return;
+  }
+  isModalOpen = true;
+  markChecklistSeen();
+  previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  backdropEl.hidden = false;
+  document.body.setAttribute('data-onboarding-open', 'true');
+  document.body.style.overflow = 'hidden';
+  const focusable = getFocusableElements();
+  const target = focusable[0] || modalEl;
+  target.focus();
+  document.addEventListener('keydown', handleKeyDown);
+}
+
+function closeModal() {
+  if (!isModalOpen || !backdropEl || !modalEl) {
+    return;
+  }
+  isModalOpen = false;
+  backdropEl.hidden = true;
+  document.body.removeAttribute('data-onboarding-open');
+  document.body.style.removeProperty('overflow');
+  document.removeEventListener('keydown', handleKeyDown);
+  if (previousFocus && typeof previousFocus.focus === 'function') {
+    previousFocus.focus();
+  } else if (resumeButtonEl) {
+    resumeButtonEl.focus();
+  }
+}
+
+function createModalShell() {
+  if (backdropEl) {
+    return;
+  }
+  backdropEl = document.createElement('div');
+  backdropEl.className = 'onboarding-backdrop';
+  backdropEl.hidden = true;
+
+  modalEl = document.createElement('div');
+  modalEl.className = 'onboarding-modal';
+  modalEl.id = 'onboarding-dialog';
+  modalEl.setAttribute('role', 'dialog');
+  modalEl.setAttribute('aria-modal', 'true');
+  modalEl.setAttribute('aria-labelledby', 'onboarding-title');
+  modalEl.setAttribute('tabindex', '-1');
+
+  const headerEl = document.createElement('header');
+
+  titleEl = document.createElement('h2');
+  titleEl.id = 'onboarding-title';
+  headerEl.appendChild(titleEl);
+
+  modalEl.appendChild(headerEl);
+
+  const mainEl = document.createElement('main');
+  progressEl = document.createElement('p');
+  progressEl.className = 'onboarding-progress';
+  progressEl.setAttribute('aria-live', 'polite');
+  mainEl.appendChild(progressEl);
+
+  taskListEl = document.createElement('ul');
+  taskListEl.className = 'onboarding-task-list';
+  mainEl.appendChild(taskListEl);
+
+  modalEl.appendChild(mainEl);
+
+  const footerEl = document.createElement('footer');
+  closeButtonEl = document.createElement('button');
+  closeButtonEl.type = 'button';
+  closeButtonEl.className = 'onboarding-close';
+  closeButtonEl.addEventListener('click', closeModal);
+  footerEl.appendChild(closeButtonEl);
+  modalEl.appendChild(footerEl);
+
+  backdropEl.appendChild(modalEl);
+  backdropEl.addEventListener('click', (event) => {
+    if (event.target === backdropEl) {
+      closeModal();
+    }
+  });
+
+  document.body.appendChild(backdropEl);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Unable to load ${url} (${response.status})`);
+  }
+  return response.json();
+}
+
+async function loadChecklistData() {
+  const targetUrl = `data/onboarding.${propertyCode}.json`;
+  try {
+    return await fetchJson(targetUrl);
+  } catch (error) {
+    if (propertyCode !== 'DEFAULT') {
+      try {
+        return await fetchJson('data/onboarding.DEFAULT.json');
+      } catch (fallbackError) {
+        throw fallbackError;
+      }
+    }
+    throw error;
+  }
+}
+
+function considerAutoOpen() {
+  if (shouldAutoOpen && !autoOpenHandled && checklistData) {
+    autoOpenHandled = true;
+    openModal();
+  }
+}
+
+async function initializeChecklist() {
+  try {
+    checklistData = await loadChecklistData();
+    renderTasks();
+    applyTranslations();
+    resumeButtonEl.disabled = false;
+    resumeButtonEl.removeAttribute('aria-disabled');
+    considerAutoOpen();
+  } catch (error) {
+    console.error('Failed to load onboarding checklist', error);
+    resumeButtonEl.disabled = true;
+    resumeButtonEl.setAttribute('aria-disabled', 'true');
+  }
+}
+
+function init() {
+  resumeButtonEl = document.getElementById('resume-orientation');
+  if (!resumeButtonEl) {
+    return;
+  }
+  resumeButtonEl.disabled = true;
+  resumeButtonEl.setAttribute('aria-disabled', 'true');
+  resumeButtonEl.setAttribute('aria-haspopup', 'dialog');
+
+  propertyCode = getStoredProperty();
+  completedTasks = new Set(loadCompletedTasks());
+  shouldAutoOpen = Boolean(router.propFromUrl) || !hasSeenChecklist();
+
+  createModalShell();
+  applyTranslations();
+
+  resumeButtonEl.setAttribute('aria-controls', 'onboarding-dialog');
+  resumeButtonEl.addEventListener('click', () => {
+    if (!checklistData) {
+      return;
+    }
+    openModal();
+  });
+
+  if (typeof hub.onLanguageChange === 'function') {
+    hub.onLanguageChange(() => {
+      applyTranslations();
+    });
+  }
+
+  initializeChecklist();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+
+export {};

--- a/translations.json
+++ b/translations.json
@@ -31,7 +31,13 @@
         "aria.qrCode": "QR code for {name}",
         "aria.call": "Call {name}",
         "aria.map": "Open {name} in Google Maps",
-        "aria.website": "Open website for {name}"
+        "aria.website": "Open website for {name}",
+        "onboarding.resume": "Resume Orientation",
+        "onboarding.title": "Orientation — Week 1",
+        "onboarding.progress": "{completed} of {total} completed",
+        "onboarding.add_to_calendar": "Add to Calendar",
+        "onboarding.estimate": "≈ {minutes} min",
+        "onboarding.close": "Close"
     },
     "es": {
         "app.title": "\ud83c\udfe8 Centro de Experiencia de Wisconsin Dells",
@@ -65,7 +71,13 @@
         "aria.qrCode": "C\u00f3digo QR de {name}",
         "aria.call": "Llamar a {name}",
         "aria.map": "Abrir {name} en Google Maps",
-        "aria.website": "Abrir el sitio web de {name}"
+        "aria.website": "Abrir el sitio web de {name}",
+        "onboarding.resume": "Reanudar orientación",
+        "onboarding.title": "Orientación — Semana 1",
+        "onboarding.progress": "{completed} de {total} completadas",
+        "onboarding.add_to_calendar": "Agregar al calendario",
+        "onboarding.estimate": "≈ {minutes} min",
+        "onboarding.close": "Cerrar"
     },
     "pt": {
         "app.title": "\ud83c\udfe8 Central de Experi\u00eancias de Wisconsin Dells",


### PR DESCRIPTION
## Summary
- add URL parameter router, theming hook, and a resume orientation entry point on the home page
- introduce an onboarding module that loads property checklists, persists progress, and offers ICS downloads with focus-trapped modal UX
- seed property and default onboarding data plus translation strings and theme variables for customization

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e7615a6fdc83338df5fe46638a2acf