### PR TITLE
feat: add guided resource playbooks

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "bank-account",
+    "title": "Open a Bank Account",
+    "est_min": 30,
+    "steps": [
+      { "id": "pick-bank", "label": "Pick a nearby bank from the map" },
+      { "id": "bring-id", "label": "Bring passport + I-94 + job offer" },
+      { "id": "deposit", "label": "Bring initial deposit (if required)" }
+    ],
+    "map_link": "https://maps.google.com/?q=bank",
+    "manager_card": [
+      "Hi, I'm a seasonal worker.",
+      "I'd like to open a basic checking account.",
+      "I have my passport and I-94."
+    ]
+  },
+  {
+    "id": "ssn-appointment",
+    "title": "Apply for a Social Security Number",
+    "est_min": 45,
+    "steps": [
+      { "id": "collect-docs", "label": "Gather passport, visa, and DS-2019" },
+      { "id": "complete-app", "label": "Fill out the SS-5 application form" },
+      { "id": "visit-office", "label": "Bring documents to the Social Security office" }
+    ],
+    "map_link": "https://maps.google.com/?q=social+security+office",
+    "manager_card": [
+      "Hello, I'm an exchange visitor.",
+      "I need to apply for a Social Security number.",
+      "I have my passport, DS-2019, and job offer letter."
+    ]
+  },
+  {
+    "id": "clinic-visit",
+    "title": "Visit a Walk-In Clinic",
+    "est_min": 20,
+    "steps": [
+      { "id": "check-hours", "label": "Check clinic hours and wait times" },
+      { "id": "bring-id-insurance", "label": "Bring your ID and insurance card" },
+      { "id": "share-symptoms", "label": "Tell the intake nurse about your symptoms" }
+    ],
+    "map_link": "https://maps.google.com/?q=clinic",
+    "manager_card": [
+      "Hi, I'm here for a walk-in visit.",
+      "I'm a J-1 seasonal employee.",
+      "Here are my ID and insurance card."
+    ]
+  }
+]

--- a/js/resources.js
+++ b/js/resources.js
@@ -1,0 +1,351 @@
+import { t } from './lib/i18n.js';
+
+const STORAGE_KEY = 'resources:progress';
+const MANAGER_KEY = 'resources:manager:visible';
+
+const resourceList = document.getElementById('resourceList');
+const emptyDetail = document.getElementById('emptyDetail');
+const detailHeader = document.getElementById('detailHeader');
+const detailTitle = document.getElementById('detailTitle');
+const detailEstimate = document.getElementById('detailEstimate');
+const mapLink = document.getElementById('mapLink');
+const managerToggle = document.getElementById('managerToggle');
+const stepList = document.getElementById('stepList');
+const managerCard = document.getElementById('managerCard');
+const managerLead = document.getElementById('managerLead');
+const managerLines = document.getElementById('managerLines');
+const pageTitleEl = document.getElementById('pageTitle');
+const pageDescriptionEl = document.getElementById('pageDescription');
+
+const DEFAULT_UI = {
+  pageTitle: 'Guided Playbooks',
+  pageDescription: 'Follow step-by-step checklists for common tasks and keep your progress.',
+  playbookListLabel: 'Playbooks',
+  showManager: 'Show to Manager',
+  hideManager: 'Hide Manager Card',
+  viewMap: 'Open map',
+  managerLead: 'Show this screen to your manager.',
+  emptyDetail: 'Select a playbook to see the checklist and manager card.'
+};
+
+const UI_KEYS = {
+  pageTitle: 'resources.pageTitle',
+  pageDescription: 'resources.pageDescription',
+  playbookListLabel: 'resources.playbookListLabel',
+  showManager: 'resources.actions.showManager',
+  hideManager: 'resources.actions.hideManager',
+  viewMap: 'resources.actions.viewMap',
+  managerLead: 'resources.managerLead',
+  emptyDetail: 'resources.emptyState'
+};
+
+const state = {
+  resources: [],
+  selectedId: null,
+  ui: { ...DEFAULT_UI },
+  progress: loadProgress(),
+  managerVisible: loadManagerVisible()
+};
+
+bootstrap().catch((error) => {
+  console.error('Failed to initialize resources page', error);
+});
+
+async function bootstrap() {
+  await loadUiStrings();
+  applyUiText();
+  await loadResources();
+  attachEventHandlers();
+  if (state.resources.length) {
+    selectResource(state.resources[0].id);
+  }
+}
+
+function attachEventHandlers() {
+  resourceList.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-resource-id]');
+    if (!button) {
+      return;
+    }
+    const { resourceId } = button.dataset;
+    if (resourceId) {
+      selectResource(resourceId);
+    }
+  });
+
+  stepList.addEventListener('change', (event) => {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement)) {
+      return;
+    }
+    if (!input.classList.contains('step-checkbox')) {
+      return;
+    }
+    const stepId = input.dataset.stepId;
+    if (!stepId || !state.selectedId) {
+      return;
+    }
+
+    if (!state.progress[state.selectedId]) {
+      state.progress[state.selectedId] = {};
+    }
+    state.progress[state.selectedId][stepId] = input.checked;
+    saveProgress();
+  });
+
+  managerToggle.addEventListener('click', () => {
+    state.managerVisible = !state.managerVisible;
+    managerToggle.setAttribute('aria-pressed', String(state.managerVisible));
+    saveManagerVisible();
+    updateManagerToggle();
+    renderManagerCard();
+  });
+}
+
+async function loadResources() {
+  try {
+    const response = await fetch('data/resources.json', { cache: 'no-cache' });
+    if (!response.ok) {
+      throw new Error(`Unable to load resources (status ${response.status})`);
+    }
+    state.resources = await response.json();
+    await renderResourceList();
+  } catch (error) {
+    console.error(error);
+    resourceList.innerHTML = '';
+    const message = document.createElement('p');
+    message.textContent = 'Unable to load resources right now. Please refresh to try again.';
+    resourceList.appendChild(message);
+  }
+}
+
+async function loadUiStrings() {
+  const entries = Object.entries(UI_KEYS);
+  const resolved = await Promise.all(
+    entries.map(async ([key, translationKey]) => {
+      const value = await maybeTranslate(translationKey, DEFAULT_UI[key]);
+      return [key, value];
+    })
+  );
+
+  for (const [key, value] of resolved) {
+    state.ui[key] = value;
+  }
+}
+
+function applyUiText() {
+  document.title = state.ui.pageTitle;
+  const activeLang = localStorage.getItem('lang') || 'en';
+  document.documentElement.setAttribute('lang', activeLang);
+  pageTitleEl.textContent = state.ui.pageTitle;
+  pageDescriptionEl.textContent = state.ui.pageDescription;
+  resourceList.setAttribute('aria-label', state.ui.playbookListLabel);
+  mapLink.textContent = state.ui.viewMap;
+  emptyDetail.textContent = state.ui.emptyDetail;
+  managerToggle.textContent = state.ui.showManager;
+  managerToggle.setAttribute('aria-pressed', String(state.managerVisible));
+}
+
+async function renderResourceList() {
+  resourceList.innerHTML = '';
+  for (const resource of state.resources) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'resource-item';
+    button.dataset.resourceId = resource.id;
+    button.setAttribute('aria-current', resource.id === state.selectedId ? 'true' : 'false');
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'resource-item-title';
+    titleSpan.textContent = await maybeTranslate(
+      `resources.playbooks.${resource.id}.title`,
+      resource.title
+    );
+
+    const estimateSpan = document.createElement('span');
+    estimateSpan.className = 'resource-item-estimate';
+    estimateSpan.textContent = await maybeTranslate(
+      'resources.estimate',
+      ({ minutes }) => `≈ ${minutes} min`,
+      { minutes: resource.est_min }
+    );
+
+    button.append(titleSpan, estimateSpan);
+    resourceList.appendChild(button);
+  }
+}
+
+async function selectResource(resourceId) {
+  if (state.selectedId === resourceId) {
+    return;
+  }
+  state.selectedId = resourceId;
+  await renderResourceList();
+  await renderDetail();
+}
+
+async function renderDetail() {
+  const resource = state.resources.find((entry) => entry.id === state.selectedId);
+  if (!resource) {
+    detailHeader.hidden = true;
+    stepList.hidden = true;
+    managerCard.hidden = true;
+    managerCard.classList.remove('is-visible');
+    emptyDetail.hidden = false;
+    return;
+  }
+
+  emptyDetail.hidden = true;
+  detailHeader.hidden = false;
+  stepList.hidden = false;
+
+  detailTitle.textContent = await maybeTranslate(
+    `resources.playbooks.${resource.id}.title`,
+    resource.title
+  );
+
+  detailEstimate.textContent = await maybeTranslate(
+    'resources.estimate',
+    ({ minutes }) => `≈ ${minutes} min`,
+    { minutes: resource.est_min }
+  );
+
+  if (resource.map_link) {
+    mapLink.href = resource.map_link;
+    mapLink.removeAttribute('aria-disabled');
+  } else {
+    mapLink.href = '#';
+    mapLink.setAttribute('aria-disabled', 'true');
+  }
+
+  await renderSteps(resource);
+  await renderManagerCard(resource);
+  updateManagerToggle();
+}
+
+async function renderSteps(resource) {
+  const resourceProgress = state.progress[resource.id] || {};
+  stepList.innerHTML = '';
+
+  for (const step of resource.steps || []) {
+    const listItem = document.createElement('li');
+    listItem.className = 'step-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'step-checkbox';
+    checkbox.dataset.stepId = step.id;
+    checkbox.id = `step-${resource.id}-${step.id}`;
+    checkbox.checked = Boolean(resourceProgress[step.id]);
+
+    const label = document.createElement('label');
+    label.setAttribute('for', checkbox.id);
+    label.textContent = await maybeTranslate(
+      `resources.playbooks.${resource.id}.steps.${step.id}`,
+      step.label
+    );
+
+    listItem.append(checkbox, label);
+    stepList.appendChild(listItem);
+  }
+}
+
+async function renderManagerCard(resource = state.resources.find((entry) => entry.id === state.selectedId)) {
+  if (!resource) {
+    managerCard.hidden = true;
+    managerCard.classList.remove('is-visible');
+    return;
+  }
+
+  if (!state.managerVisible) {
+    managerCard.hidden = true;
+    managerCard.classList.remove('is-visible');
+    return;
+  }
+
+  managerCard.hidden = false;
+  managerCard.classList.add('is-visible');
+
+  managerLead.textContent = state.ui.managerLead;
+  managerLines.innerHTML = '';
+
+  const lines = await Promise.all(
+    (resource.manager_card || []).map((line, index) =>
+      maybeTranslate(
+        `resources.playbooks.${resource.id}.manager_card.${index}`,
+        line
+      )
+    )
+  );
+
+  for (const line of lines) {
+    const p = document.createElement('p');
+    p.className = 'manager-card-line';
+    p.textContent = line;
+    managerLines.appendChild(p);
+  }
+}
+
+function updateManagerToggle() {
+  if (state.managerVisible) {
+    managerToggle.textContent = state.ui.hideManager;
+  } else {
+    managerToggle.textContent = state.ui.showManager;
+  }
+  managerToggle.setAttribute('aria-pressed', String(state.managerVisible));
+}
+
+function loadProgress() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Unable to parse stored progress', error);
+    return {};
+  }
+}
+
+function saveProgress() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.progress));
+  } catch (error) {
+    console.warn('Unable to save progress', error);
+  }
+}
+
+function loadManagerVisible() {
+  const stored = localStorage.getItem(MANAGER_KEY);
+  if (stored === null) {
+    return false;
+  }
+  return stored === 'true';
+}
+
+function saveManagerVisible() {
+  try {
+    localStorage.setItem(MANAGER_KEY, String(state.managerVisible));
+  } catch (error) {
+    console.warn('Unable to save manager card preference', error);
+  }
+}
+
+async function maybeTranslate(key, fallback, vars = {}) {
+  try {
+    const translated = await t(key, vars);
+    if (typeof translated === 'string' && translated !== key) {
+      return translated;
+    }
+  } catch (error) {
+    console.warn(`Translation lookup failed for ${key}`, error);
+  }
+
+  if (typeof fallback === 'function') {
+    return fallback(vars);
+  }
+
+  return fallback;
+}

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Guided Playbooks</title>
+    <link rel="stylesheet" href="css/theme.css" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--theme-background, #f7f8fb);
+        color: var(--theme-text, #0f172a);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      header {
+        background: linear-gradient(135deg, var(--theme-gradient-start, #4338ca), var(--theme-gradient-end, #06b6d4));
+        color: var(--theme-header-text, #fff);
+        padding: 2.5rem 1.5rem 2rem;
+        text-align: center;
+        position: relative;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 4vw, 2.4rem);
+      }
+
+      header p {
+        max-width: 640px;
+        margin: 0.75rem auto 0;
+        font-size: clamp(1rem, 2.5vw, 1.2rem);
+        opacity: 0.95;
+      }
+
+      header a.back-link {
+        position: absolute;
+        left: 1.5rem;
+        top: 1.25rem;
+        color: inherit;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      main {
+        flex: 1;
+        padding: 2rem 1.5rem 3rem;
+        display: flex;
+        justify-content: center;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+        gap: 2rem;
+        width: min(1200px, 100%);
+      }
+
+      .resource-list {
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(12px);
+        border-radius: 18px;
+        padding: 1rem;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .resource-item {
+        width: 100%;
+        border: none;
+        border-radius: 14px;
+        padding: 1rem 1.1rem;
+        text-align: left;
+        background: #f8fafc;
+        color: inherit;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .resource-item:is(:hover, :focus-visible) {
+        outline: none;
+        transform: translateY(-2px);
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+        background: #eef2ff;
+      }
+
+      .resource-item[aria-current="true"] {
+        background: var(--theme-primary-dark, #4338ca);
+        color: #fff;
+        box-shadow: 0 12px 30px rgba(67, 56, 202, 0.45);
+      }
+
+      .resource-item-title {
+        font-weight: 700;
+        font-size: 1.05rem;
+      }
+
+      .resource-item-estimate {
+        font-size: 0.95rem;
+        opacity: 0.85;
+      }
+
+      .resource-detail {
+        background: rgba(255, 255, 255, 0.92);
+        backdrop-filter: blur(16px);
+        border-radius: 20px;
+        padding: 1.75rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.15);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .resource-detail header {
+        position: static;
+        padding: 0;
+        background: none;
+        color: inherit;
+        box-shadow: none;
+        text-align: left;
+      }
+
+      .detail-title {
+        font-size: clamp(1.6rem, 3vw, 2.1rem);
+        margin-bottom: 0.3rem;
+      }
+
+      .detail-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      .detail-estimate {
+        font-weight: 600;
+        color: var(--theme-primary-dark, #4338ca);
+      }
+
+      .detail-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-left: auto;
+      }
+
+      .primary-button,
+      .ghost-button {
+        border-radius: 999px;
+        font-weight: 600;
+        padding: 0.55rem 1.2rem;
+        border: none;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+
+      .primary-button {
+        background: var(--theme-primary-dark, #4338ca);
+        color: #fff;
+        box-shadow: 0 10px 22px rgba(67, 56, 202, 0.35);
+      }
+
+      .ghost-button {
+        background: rgba(15, 23, 42, 0.08);
+        color: inherit;
+        border: 1px solid rgba(15, 23, 42, 0.15);
+      }
+
+      .primary-button:is(:hover, :focus-visible),
+      .ghost-button:is(:hover, :focus-visible) {
+        outline: none;
+        transform: translateY(-1px);
+        box-shadow: 0 12px 28px rgba(15, 23, 42, 0.2);
+      }
+
+      .ghost-button:is(:hover, :focus-visible) {
+        background: rgba(15, 23, 42, 0.12);
+      }
+
+      .step-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+      }
+
+      .step-item {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.75rem;
+        align-items: start;
+        padding: 0.9rem 1rem;
+        border-radius: 14px;
+        background: rgba(148, 163, 184, 0.12);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+      }
+
+      .step-checkbox {
+        width: 1.35rem;
+        height: 1.35rem;
+        margin-top: 0.2rem;
+        border-radius: 6px;
+        border: 2px solid rgba(67, 56, 202, 0.6);
+        cursor: pointer;
+      }
+
+      .step-checkbox:focus-visible {
+        outline: 3px solid rgba(14, 165, 233, 0.45);
+        outline-offset: 2px;
+      }
+
+      .manager-card {
+        border-radius: 20px;
+        padding: 1.8rem 1.5rem;
+        background: #0f172a;
+        color: #f8fafc;
+        display: none;
+        gap: 1.5rem;
+      }
+
+      .manager-card.is-visible {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .manager-card-lead {
+        font-size: clamp(1.15rem, 3vw, 1.4rem);
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .manager-card-line {
+        font-size: clamp(2.2rem, 5vw, 3rem);
+        line-height: 1.2;
+        font-weight: 700;
+        text-align: center;
+        padding: 0.35rem 0.5rem;
+        border-radius: 12px;
+        background: rgba(15, 23, 42, 0.75);
+        border: 2px solid rgba(248, 250, 252, 0.55);
+      }
+
+      .empty-detail {
+        margin: 0 auto;
+        max-width: 420px;
+        text-align: center;
+        font-size: 1.1rem;
+        opacity: 0.75;
+      }
+
+      @media (max-width: 960px) {
+        main {
+          padding-inline: 1rem;
+        }
+
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        .resource-item {
+          padding: 0.9rem 1rem;
+        }
+
+        .resource-detail {
+          padding: 1.35rem;
+        }
+
+        .detail-actions {
+          width: 100%;
+          justify-content: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <a class="back-link" href="index.html">← Hub</a>
+      <h1 id="pageTitle">Guided Playbooks</h1>
+      <p id="pageDescription">
+        Follow step-by-step checklists for common tasks and keep your progress.
+      </p>
+    </header>
+    <main>
+      <section class="layout">
+        <aside class="resource-list" id="resourceList" aria-label="Playbooks"></aside>
+        <section class="resource-detail" aria-live="polite">
+          <div id="emptyDetail" class="empty-detail">
+            Select a playbook to see the checklist and manager card.
+          </div>
+          <header id="detailHeader" hidden>
+            <h2 class="detail-title" id="detailTitle"></h2>
+            <div class="detail-meta">
+              <span class="detail-estimate" id="detailEstimate"></span>
+              <div class="detail-actions">
+                <a
+                  id="mapLink"
+                  class="ghost-button"
+                  href="#"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Open map
+                </a>
+                <button
+                  class="primary-button"
+                  type="button"
+                  id="managerToggle"
+                  aria-controls="managerCard"
+                >
+                  Show to Manager
+                </button>
+              </div>
+            </div>
+          </header>
+          <ol class="step-list" id="stepList" hidden></ol>
+          <section class="manager-card" id="managerCard" hidden>
+            <p class="manager-card-lead" id="managerLead"></p>
+            <div id="managerLines" aria-live="polite"></div>
+          </section>
+        </section>
+      </section>
+    </main>
+    <script type="module" src="js/resources.js"></script>
+  </body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,14 @@
 // J1hub PWA – offline support with fallback page
-const VERSION = "j1hub-v3";
+const VERSION = "j1hub-v4";
 const BASE = self.location.pathname.replace(/\/[^/]*$/, "/");
 const ASSETS = [
   `${BASE}`, `${BASE}index.html`, `${BASE}hotel.html`, `${BASE}map.html`,
-  `${BASE}qr.html`, `${BASE}qr-sheet.html`, `${BASE}admin.html`,
+  `${BASE}resources.html`, `${BASE}qr.html`, `${BASE}qr-sheet.html`, `${BASE}admin.html`,
   `${BASE}import-hotels.html`, `${BASE}dashboard.html`, `${BASE}feedback.html`,
   `${BASE}offline.html`,
   `${BASE}hotels.json`, `${BASE}resources.json`, `${BASE}housing.json`, `${BASE}translations.json`,
+  `${BASE}data/resources.json`, `${BASE}js/resources.js`,
+  `${BASE}translations/en.json`, `${BASE}translations/es.json`, `${BASE}translations/pt.json`,
   `${BASE}manifest.json`, `${BASE}j1hub-192.png`, `${BASE}j1hub-512.png`
 ];
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,56 @@
+{
+  "resources": {
+    "pageTitle": "Guided Playbooks",
+    "pageDescription": "Step-by-step support for J-1 seasonal workers.",
+    "playbookListLabel": "Playbooks",
+    "actions": {
+      "showManager": "Show to Manager",
+      "hideManager": "Hide Manager Card",
+      "viewMap": "Open map"
+    },
+    "managerLead": "Show this screen to your manager.",
+    "emptyState": "Select a playbook to see the checklist and manager card.",
+    "estimate": "≈ {minutes} min",
+    "playbooks": {
+      "bank-account": {
+        "title": "Open a Bank Account",
+        "steps": {
+          "pick-bank": "Pick a nearby bank from the map",
+          "bring-id": "Bring passport + I-94 + job offer",
+          "deposit": "Bring initial deposit (if required)"
+        },
+        "manager_card": {
+          "0": "Hi, I'm a seasonal worker.",
+          "1": "I'd like to open a basic checking account.",
+          "2": "I have my passport and I-94."
+        }
+      },
+      "ssn-appointment": {
+        "title": "Apply for a Social Security Number",
+        "steps": {
+          "collect-docs": "Gather passport, visa, and DS-2019",
+          "complete-app": "Fill out the SS-5 application form",
+          "visit-office": "Bring documents to the Social Security office"
+        },
+        "manager_card": {
+          "0": "Hello, I'm an exchange visitor.",
+          "1": "I need to apply for a Social Security number.",
+          "2": "I have my passport, DS-2019, and job offer letter."
+        }
+      },
+      "clinic-visit": {
+        "title": "Visit a Walk-In Clinic",
+        "steps": {
+          "check-hours": "Check clinic hours and wait times",
+          "bring-id-insurance": "Bring your ID and insurance card",
+          "share-symptoms": "Tell the intake nurse about your symptoms"
+        },
+        "manager_card": {
+          "0": "Hi, I'm here for a walk-in visit.",
+          "1": "I'm a J-1 seasonal employee.",
+          "2": "Here are my ID and insurance card."
+        }
+      }
+    }
+  }
+}

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,56 @@
+{
+  "resources": {
+    "pageTitle": "Guías paso a paso",
+    "pageDescription": "Apoyo paso a paso para trabajadores temporales J-1.",
+    "playbookListLabel": "Guías",
+    "actions": {
+      "showManager": "Mostrar al gerente",
+      "hideManager": "Ocultar tarjeta para gerente",
+      "viewMap": "Abrir mapa"
+    },
+    "managerLead": "Muestra esta pantalla a tu gerente.",
+    "emptyState": "Selecciona una guía para ver la lista y la tarjeta para gerente.",
+    "estimate": "≈ {minutes} min",
+    "playbooks": {
+      "bank-account": {
+        "title": "Abrir una cuenta bancaria",
+        "steps": {
+          "pick-bank": "Elige un banco cercano en el mapa",
+          "bring-id": "Lleva pasaporte + I-94 + oferta de trabajo",
+          "deposit": "Lleva un depósito inicial (si lo piden)"
+        },
+        "manager_card": {
+          "0": "Hola, soy un trabajador temporal.",
+          "1": "Quisiera abrir una cuenta corriente básica.",
+          "2": "Tengo mi pasaporte y el formulario I-94."
+        }
+      },
+      "ssn-appointment": {
+        "title": "Solicitar un número de Seguro Social",
+        "steps": {
+          "collect-docs": "Reúne pasaporte, visa y DS-2019",
+          "complete-app": "Completa el formulario SS-5",
+          "visit-office": "Lleva los documentos a la oficina del Seguro Social"
+        },
+        "manager_card": {
+          "0": "Hola, soy un visitante de intercambio.",
+          "1": "Necesito solicitar un número de Seguro Social.",
+          "2": "Tengo mi pasaporte, DS-2019 y carta de oferta laboral."
+        }
+      },
+      "clinic-visit": {
+        "title": "Visitar una clínica sin cita",
+        "steps": {
+          "check-hours": "Revisa el horario y el tiempo de espera de la clínica",
+          "bring-id-insurance": "Lleva tu identificación y tarjeta de seguro",
+          "share-symptoms": "Explica tus síntomas a la enfermera de admisión"
+        },
+        "manager_card": {
+          "0": "Hola, vine para una visita sin cita.",
+          "1": "Soy un empleado de temporada con visa J-1.",
+          "2": "Aquí están mi identificación y tarjeta de seguro."
+        }
+      }
+    }
+  }
+}

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1,0 +1,56 @@
+{
+  "resources": {
+    "pageTitle": "Guias orientados",
+    "pageDescription": "Passo a passo para trabalhadores sazonais J-1.",
+    "playbookListLabel": "Guias",
+    "actions": {
+      "showManager": "Mostrar ao gerente",
+      "hideManager": "Ocultar cartão do gerente",
+      "viewMap": "Abrir mapa"
+    },
+    "managerLead": "Mostre esta tela ao seu gerente.",
+    "emptyState": "Selecione um guia para ver a lista e o cartão do gerente.",
+    "estimate": "≈ {minutes} min",
+    "playbooks": {
+      "bank-account": {
+        "title": "Abrir uma conta bancária",
+        "steps": {
+          "pick-bank": "Escolha um banco próximo no mapa",
+          "bring-id": "Leve passaporte + I-94 + carta de trabalho",
+          "deposit": "Leve um depósito inicial (se necessário)"
+        },
+        "manager_card": {
+          "0": "Olá, sou um trabalhador sazonal.",
+          "1": "Gostaria de abrir uma conta corrente básica.",
+          "2": "Tenho meu passaporte e o I-94."
+        }
+      },
+      "ssn-appointment": {
+        "title": "Solicitar um número do Social Security",
+        "steps": {
+          "collect-docs": "Separe passaporte, visto e DS-2019",
+          "complete-app": "Preencha o formulário SS-5",
+          "visit-office": "Leve os documentos ao escritório do Social Security"
+        },
+        "manager_card": {
+          "0": "Olá, sou um participante de intercâmbio.",
+          "1": "Preciso solicitar um número do Social Security.",
+          "2": "Estou com meu passaporte, DS-2019 e carta de oferta."
+        }
+      },
+      "clinic-visit": {
+        "title": "Visitar uma clínica sem horário marcado",
+        "steps": {
+          "check-hours": "Verifique o horário e a fila da clínica",
+          "bring-id-insurance": "Leve sua identidade e cartão do seguro",
+          "share-symptoms": "Conte seus sintomas para a enfermeira de triagem"
+        },
+        "manager_card": {
+          "0": "Olá, estou aqui para um atendimento sem horário.",
+          "1": "Sou um funcionário sazonal com visto J-1.",
+          "2": "Aqui estão minha identidade e cartão do seguro."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated resources playbook page with checklist progress, manager card view, and translation hooks
- seed guided resource data and localized strings for English, Spanish, and Portuguese
- update the service worker cache manifest to include new assets for offline support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e76e965f748333a70d9c058a5aa821