### PR TITLE
feat: add QR presets and analytics pixel logging

### DIFF
--- a/apps-script/hitlogger.gs
+++ b/apps-script/hitlogger.gs
@@ -1,0 +1,77 @@
+const SHEET_NAME = 'Hits';
+const TRANSPARENT_GIF_BASE64 = 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+function doGet(e) {
+  const lock = LockService.getScriptLock();
+  try {
+    lock.waitLock(5000);
+  } catch (error) {
+    return createPixelResponse();
+  }
+
+  try {
+    const sheet = getSheet();
+    const parameters = (e && e.parameter) || {};
+    const headers = (e && e.headers) || {};
+    const context = (e && e.context) || {};
+
+    const timestamp = parseTimestamp(parameters.ts);
+    const path = sanitize(parameters.p);
+    const prop = sanitize(parameters.prop);
+    const lang = sanitize(parameters.lang);
+    const userAgent = sanitize(headers['User-Agent'] || headers['user-agent']);
+    const ip = sanitize(context.clientIp);
+
+    appendRow(sheet, [timestamp, path, prop, lang, userAgent, ip]);
+  } finally {
+    lock.releaseLock();
+  }
+
+  return createPixelResponse();
+}
+
+function getSheet() {
+  const spreadsheet = SpreadsheetApp.getActive();
+  let sheet = spreadsheet.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(SHEET_NAME);
+  }
+
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow(['timestamp', 'path', 'prop', 'lang', 'userAgent', 'ip']);
+  }
+
+  return sheet;
+}
+
+function appendRow(sheet, values) {
+  sheet.appendRow(values);
+}
+
+function parseTimestamp(rawTs) {
+  const ts = Number(rawTs);
+  if (!rawTs || Number.isNaN(ts)) {
+    return new Date();
+  }
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) {
+    return new Date();
+  }
+  return date;
+}
+
+function sanitize(value) {
+  if (!value) {
+    return '';
+  }
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return '';
+  }
+  return stringValue.slice(0, 256);
+}
+
+function createPixelResponse() {
+  const pixelBytes = Utilities.base64Decode(TRANSPARENT_GIF_BASE64);
+  return ContentService.createTextOutput(pixelBytes).setMimeType(ContentService.MimeType.GIF);
+}

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -1,0 +1,37 @@
+# Analytics Pixel & Hit Logger
+
+This project uses a lightweight tracking pixel to understand which property and language combinations are loading each page. Hits are processed by a Google Apps Script web app that writes to a Google Sheet.
+
+## Apps Script deployment
+
+1. Open [script.google.com](https://script.google.com/) with the Google account that owns the target spreadsheet.
+2. Create a new **Apps Script** project and connect it to the Google Sheet where you want to store the logs.
+3. Replace the default code with the contents of [`apps-script/hitlogger.gs`](../../apps-script/hitlogger.gs).
+4. Click **Deploy → Test deployments** to grant script permissions, then choose **Deploy → Manage deployments** and create a **Web app** deployment:
+   - **Execute as:** Me
+   - **Who has access:** Anyone with the link (or restrict to your allowlist as needed)
+5. Copy the web app URL; this is your `HIT_URL`.
+
+The spreadsheet will automatically create a `Hits` sheet with the columns `timestamp`, `path`, `prop`, `lang`, `userAgent`, and `ip` on the first request.
+
+## Adding the pixel to the site
+
+Set a global JavaScript variable before loading any page-specific bundles:
+
+```html
+<script>
+  window.HIT_URL = 'https://script.google.com/macros/s/DEPLOYMENT_ID/exec';
+</script>
+```
+
+Add the snippet (ideally inside `index.html` so it propagates through shared layouts). Pages that load `js/qr.js` will automatically request the 1×1 GIF at:
+
+```
+${HIT_URL}?p=${path}&prop=${prop}&lang=${lang}&ts=${Date.now()}
+```
+
+`prop` and `lang` values are taken from the current page URL query string to avoid storing any PII.
+
+## Regenerating the QR preset page
+
+`qr.html` now imports `js/qr.js`, which builds property-specific links (with language presets) and renders QR codes through the CDN-hosted `qrcodejs` library. Ensure the pixel snippet above runs before `js/qr.js` so analytics hits reach the Apps Script endpoint on each page view.

--- a/js/qr.js
+++ b/js/qr.js
@@ -1,0 +1,391 @@
+const PRESETS = {
+  onboarding: {
+    label: 'Onboarding',
+    path: '/',
+    search: { view: 'onboarding' },
+  },
+  events: {
+    label: 'Events',
+    path: '/events.html',
+  },
+  resources: {
+    label: 'Resources',
+    path: '/resources.html',
+  },
+};
+
+const qrWrapper = document.getElementById('qr-wrapper');
+const form = document.getElementById('qr-form');
+const baseInput = document.getElementById('base-url');
+const pathInput = document.getElementById('destination-path');
+const propertyInput = document.getElementById('property-code');
+const languageSelect = document.getElementById('language-select');
+const urlPreviewInput = document.getElementById('generated-url');
+const downloadButton = document.getElementById('download-btn');
+const copyButton = document.getElementById('copy-btn');
+const formMessage = document.getElementById('form-message');
+const presetButtons = Array.from(document.querySelectorAll('[data-preset]'));
+const QRCodeLibrary = window.QRCode;
+
+let qrCodeInstance = null;
+let presetSearchParams = new URLSearchParams();
+let activePresetKey = null;
+
+function resetQrWrapper() {
+  qrWrapper.innerHTML = '';
+  qrWrapper.classList.remove('empty');
+}
+
+function setMessage(message = '', tone = 'neutral') {
+  if (!formMessage) {
+    return;
+  }
+  formMessage.textContent = message || '';
+  formMessage.hidden = !message;
+  formMessage.classList.remove('is-error', 'is-success');
+  if (!message) {
+    return;
+  }
+  if (tone === 'error') {
+    formMessage.classList.add('is-error');
+  } else if (tone === 'success') {
+    formMessage.classList.add('is-success');
+  }
+}
+
+function buildDestinationUrl() {
+  const baseValue = (baseInput?.value || '').trim();
+  if (!baseValue) {
+    return null;
+  }
+
+  let baseUrl;
+  try {
+    baseUrl = new URL(baseValue);
+  } catch (error) {
+    return null;
+  }
+
+  const rawPath = (pathInput?.value || '').trim() || '/';
+  let destinationUrl;
+  try {
+    destinationUrl = new URL(rawPath, baseUrl);
+  } catch (error) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams(destinationUrl.search);
+  presetSearchParams.forEach((value, key) => {
+    if (value === null || typeof value === 'undefined') {
+      return;
+    }
+    searchParams.set(key, value);
+  });
+
+  const propertyValue = (propertyInput?.value || '').trim();
+  if (propertyValue) {
+    searchParams.set('prop', propertyValue.toUpperCase());
+  } else {
+    searchParams.delete('prop');
+  }
+
+  const langValue = (languageSelect?.value || '').trim();
+  if (langValue) {
+    searchParams.set('lang', langValue);
+  } else {
+    searchParams.delete('lang');
+  }
+
+  const query = searchParams.toString();
+  destinationUrl.search = query;
+  return destinationUrl.toString();
+}
+
+function updateUrlPreview() {
+  const builtUrl = buildDestinationUrl();
+  if (urlPreviewInput) {
+    urlPreviewInput.value = builtUrl || '';
+  }
+  return builtUrl;
+}
+
+function setActivePreset(key) {
+  activePresetKey = key;
+  presetButtons.forEach((button) => {
+    const isActive = button.dataset.preset === key;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function applyPreset(key) {
+  const preset = PRESETS[key];
+  if (!preset) {
+    return;
+  }
+  setActivePreset(key);
+  const nextPath = typeof preset.path === 'string' ? preset.path : '/';
+  pathInput.value = nextPath;
+  presetSearchParams = new URLSearchParams();
+  if (preset.search) {
+    Object.entries(preset.search).forEach(([searchKey, value]) => {
+      if (typeof value === 'undefined' || value === null) {
+        return;
+      }
+      presetSearchParams.set(searchKey, value);
+    });
+  }
+  setMessage('');
+  updateUrlPreview();
+}
+
+function clearPresetIfEdited() {
+  if (!activePresetKey) {
+    return;
+  }
+  setActivePreset(null);
+  presetSearchParams = new URLSearchParams();
+}
+
+function createQrCode(url) {
+  if (!QRCodeLibrary) {
+    console.warn('QR code library unavailable');
+    return;
+  }
+  resetQrWrapper();
+  qrCodeInstance = new QRCodeLibrary(qrWrapper, {
+    text: url,
+    width: 220,
+    height: 220,
+    colorDark: '#1f2937',
+    colorLight: '#ffffff',
+    correctLevel: QRCode.CorrectLevel.H,
+  });
+}
+
+function enableDownload() {
+  if (!downloadButton) {
+    return;
+  }
+  const canvas = qrWrapper.querySelector('canvas');
+  const image = qrWrapper.querySelector('img');
+  if (!canvas && !image) {
+    downloadButton.disabled = true;
+    downloadButton.removeAttribute('data-file-name');
+    return;
+  }
+
+  const propertyValue = (propertyInput?.value || '').trim().toUpperCase();
+  const langValue = (languageSelect?.value || '').trim();
+  const pieces = ['j1hub'];
+  if (propertyValue) {
+    pieces.push(propertyValue);
+  }
+  if (langValue) {
+    pieces.push(langValue);
+  }
+  const fileName = `${pieces.join('-')}-qr.png`;
+  downloadButton.dataset.fileName = fileName;
+  downloadButton.disabled = false;
+  downloadButton.onclick = () => {
+    let dataUrl = '';
+    if (canvas) {
+      dataUrl = canvas.toDataURL('image/png');
+    } else if (image) {
+      const tempCanvas = document.createElement('canvas');
+      tempCanvas.width = image.width;
+      tempCanvas.height = image.height;
+      const ctx = tempCanvas.getContext('2d');
+      if (!ctx) {
+        return;
+      }
+      ctx.drawImage(image, 0, 0);
+      dataUrl = tempCanvas.toDataURL('image/png');
+    }
+    if (!dataUrl) {
+      return;
+    }
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = fileName;
+    link.click();
+  };
+}
+
+function sanitizeAndSetProperty(value) {
+  if (!propertyInput) {
+    return;
+  }
+  const sanitized = (value || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+  propertyInput.value = sanitized;
+}
+
+function initializePresetButtons() {
+  presetButtons.forEach((button) => {
+    button.setAttribute('aria-pressed', 'false');
+    button.addEventListener('click', () => {
+      const presetKey = button.dataset.preset;
+      if (!presetKey) {
+        return;
+      }
+      applyPreset(presetKey);
+    });
+  });
+}
+
+function hydrateFromQuery() {
+  const params = new URLSearchParams(window.location.search);
+  const base = params.get('base');
+  const path = params.get('path');
+  const prop = params.get('prop');
+  const lang = params.get('lang');
+  const preset = params.get('preset');
+
+  if (base && baseInput) {
+    baseInput.value = base;
+  }
+  if (path && pathInput) {
+    pathInput.value = path;
+  }
+  if (prop) {
+    sanitizeAndSetProperty(prop);
+  }
+  if (
+    lang &&
+    languageSelect &&
+    languageSelect.querySelector(`option[value="${lang}"]`)
+  ) {
+    languageSelect.value = lang;
+  }
+  if (preset && PRESETS[preset]) {
+    applyPreset(preset);
+    return;
+  }
+  updateUrlPreview();
+}
+
+function attachFormListeners() {
+  if (!form) {
+    return;
+  }
+  if (baseInput) {
+    baseInput.addEventListener('input', () => {
+      setMessage('');
+      updateUrlPreview();
+    });
+  }
+
+  if (pathInput) {
+    pathInput.addEventListener('input', () => {
+      clearPresetIfEdited();
+      setMessage('');
+      updateUrlPreview();
+    });
+  }
+
+  if (propertyInput) {
+    propertyInput.addEventListener('input', (event) => {
+      const originalPosition = event.target.selectionStart || 0;
+      sanitizeAndSetProperty(event.target.value);
+      if (typeof event.target.setSelectionRange === 'function') {
+        event.target.setSelectionRange(originalPosition, originalPosition);
+      }
+      updateUrlPreview();
+    });
+  }
+
+  if (languageSelect) {
+    languageSelect.addEventListener('change', () => {
+      updateUrlPreview();
+    });
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const builtUrl = updateUrlPreview();
+    if (!builtUrl) {
+      setMessage('Please enter a valid base URL to build the QR link.', 'error');
+      qrWrapper.innerHTML = '';
+      qrWrapper.classList.add('empty');
+      if (downloadButton) {
+        downloadButton.disabled = true;
+      }
+      return;
+    }
+
+    setMessage('');
+
+    if (qrCodeInstance) {
+      qrCodeInstance.clear();
+    }
+    createQrCode(builtUrl);
+    setTimeout(enableDownload, 50);
+  });
+
+  if (!copyButton) {
+    return;
+  }
+
+  copyButton.addEventListener('click', async () => {
+    const value = urlPreviewInput.value;
+    if (!value) {
+      setMessage('Generate a link before copying.', 'error');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      setMessage('Link copied to clipboard.', 'success');
+    } catch (error) {
+      console.warn('Unable to copy link', error);
+      setMessage('Copy unavailable in this browser.', 'error');
+    }
+  });
+}
+
+function logHitPixel() {
+  const hitUrl = window.HIT_URL;
+  if (!hitUrl) {
+    return;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const pixelParams = new URLSearchParams({
+      p: window.location.pathname || '/',
+      prop: params.get('prop') || '',
+      lang: params.get('lang') || '',
+      ts: Date.now().toString(),
+    });
+    const pixel = new Image(1, 1);
+    pixel.decoding = 'async';
+    pixel.referrerPolicy = 'no-referrer-when-downgrade';
+    pixel.alt = '';
+    pixel.src = `${hitUrl}?${pixelParams.toString()}`;
+    pixel.style.position = 'absolute';
+    pixel.style.width = '1px';
+    pixel.style.height = '1px';
+    pixel.style.opacity = '0';
+    document.body.appendChild(pixel);
+  } catch (error) {
+    console.warn('Unable to send analytics hit', error);
+  }
+}
+
+function init() {
+  if (!form || !qrWrapper) {
+    return;
+  }
+  initializePresetButtons();
+  hydrateFromQuery();
+  attachFormListeners();
+  logHitPixel();
+  if (!QRCodeLibrary) {
+    setMessage('QR code library failed to load.', 'error');
+    return;
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/qr.html
+++ b/qr.html
@@ -59,6 +59,7 @@
     form {
       display: grid;
       gap: 1rem;
+      margin-top: 1.5rem;
     }
 
     label {
@@ -66,20 +67,106 @@
       font-weight: 600;
       color: #312e81;
       font-size: 0.95rem;
+      display: block;
+      margin-bottom: 0.35rem;
     }
 
-    input[type='url'] {
+    input[type='url'],
+    input[type='text'],
+    select {
       padding: 0.8rem 1rem;
       border-radius: 12px;
       border: 1px solid rgba(79, 70, 229, 0.25);
       font-size: 1rem;
       outline: none;
       transition: border 0.2s ease, box-shadow 0.2s ease;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.96);
     }
 
-    input[type='url']:focus {
+    input[type='url']:focus,
+    input[type='text']:focus,
+    select:focus {
       border-color: #4f46e5;
       box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+    }
+
+    .preset-toolbar {
+      margin: 1.5rem 0 0.5rem;
+      text-align: left;
+    }
+
+    .preset-toolbar h2 {
+      margin: 0 0 0.35rem;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #4338ca;
+    }
+
+    .preset-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .preset-buttons button {
+      border-radius: 999px;
+      border: 1px solid rgba(79, 70, 229, 0.2);
+      background: rgba(79, 70, 229, 0.08);
+      color: #312e81;
+      font-weight: 600;
+      padding: 0.55rem 1.1rem;
+      cursor: pointer;
+      transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+
+    .preset-buttons button:hover,
+    .preset-buttons button:focus {
+      background: rgba(79, 70, 229, 0.18);
+      box-shadow: 0 10px 20px rgba(79, 70, 229, 0.16);
+      transform: translateY(-1px);
+    }
+
+    .preset-buttons button.is-active {
+      background: linear-gradient(135deg, #4f46e5, #7c3aed);
+      color: #fff;
+      border-color: transparent;
+      box-shadow: 0 12px 24px rgba(79, 70, 229, 0.35);
+    }
+
+    .url-preview {
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .url-preview__field {
+      display: flex;
+      gap: 0.5rem;
+      align-items: stretch;
+    }
+
+    .url-preview__field input {
+      flex: 1;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        sans-serif;
+    }
+
+    .copy-button {
+      border-radius: 12px;
+      border: none;
+      background: rgba(17, 24, 39, 0.9);
+      color: #fff;
+      font-weight: 600;
+      padding: 0 1.1rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .copy-button:hover,
+    .copy-button:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
     }
 
     button {
@@ -107,6 +194,32 @@
       align-items: center;
       justify-content: center;
       gap: 0.4rem;
+    }
+
+    .form-message {
+      margin: 0;
+      font-size: 0.9rem;
+      text-align: left;
+      border-radius: 10px;
+      padding: 0.75rem 1rem;
+      background: rgba(248, 250, 252, 0.8);
+      border: 1px solid transparent;
+    }
+
+    .form-message[hidden] {
+      display: none;
+    }
+
+    .form-message.is-error {
+      color: #b91c1c;
+      border-color: rgba(220, 38, 38, 0.2);
+      background: rgba(254, 226, 226, 0.5);
+    }
+
+    .form-message.is-success {
+      color: #065f46;
+      border-color: rgba(16, 185, 129, 0.25);
+      background: rgba(236, 253, 245, 0.7);
     }
 
     .qr-wrapper {
@@ -163,27 +276,99 @@
       .qr-wrapper {
         background: rgba(79, 70, 229, 0.15);
       }
+
+      .copy-button {
+        background: rgba(229, 231, 235, 0.12);
+      }
     }
   </style>
 </head>
 <body>
   <div class="card">
     <h1>Create a QR Code</h1>
-    <p class="description">Paste any link below and instantly generate a QR code you can share or download.</p>
-    <form id="qr-form">
-      <label for="qr-url">URL</label>
-      <input
-        type="url"
-        id="qr-url"
-        name="qr-url"
-        placeholder="https://example.com"
-        required
-        pattern="https?://.+"
-      />
+    <p class="description">
+      Build a property-ready link with language support and instantly turn it into a
+      downloadable QR code.
+    </p>
+
+    <section class="preset-toolbar" aria-labelledby="preset-heading">
+      <h2 id="preset-heading">Quick presets</h2>
+      <div class="preset-buttons" role="group" aria-label="Destination presets">
+        <button type="button" data-preset="onboarding" aria-pressed="false">Onboarding</button>
+        <button type="button" data-preset="events" aria-pressed="false">Events</button>
+        <button type="button" data-preset="resources" aria-pressed="false">Resources</button>
+      </div>
+    </section>
+
+    <form id="qr-form" novalidate>
+      <div>
+        <label for="base-url">Base URL</label>
+        <input
+          type="url"
+          id="base-url"
+          name="base-url"
+          placeholder="https://example.com"
+          required
+          value="https://j1hub.org/"
+          inputmode="url"
+        />
+      </div>
+
+      <div>
+        <label for="destination-path">Destination path or page</label>
+        <input
+          type="text"
+          id="destination-path"
+          name="destination-path"
+          placeholder="/events.html"
+          value="/"
+          autocomplete="off"
+        />
+      </div>
+
+      <div>
+        <label for="property-code">Property code (optional)</label>
+        <input
+          type="text"
+          id="property-code"
+          name="property-code"
+          placeholder="KAL"
+          pattern="^[A-Za-z0-9]{2,12}$"
+          autocomplete="off"
+          inputmode="text"
+        />
+      </div>
+
+      <div>
+        <label for="language-select">Language (optional)</label>
+        <select id="language-select" name="language-select">
+          <option value="">Default</option>
+          <option value="en">English</option>
+          <option value="es">Español</option>
+          <option value="pt">Português</option>
+        </select>
+      </div>
+
+      <div class="url-preview">
+        <label for="generated-url">Generated link</label>
+        <div class="url-preview__field">
+          <input
+            type="text"
+            id="generated-url"
+            name="generated-url"
+            readonly
+            aria-live="polite"
+            aria-label="Final link preview"
+          />
+          <button type="button" id="copy-btn" class="copy-button">Copy</button>
+        </div>
+      </div>
+
       <button type="submit">Generate QR</button>
+      <p id="form-message" class="form-message" role="alert" hidden></p>
     </form>
     <div id="qr-wrapper" class="qr-wrapper empty" role="status" aria-live="polite">
-      Enter a URL and click "Generate QR" to see your code here.
+      Configure a link above and click "Generate QR" to preview the code here.
     </div>
     <button id="download-btn" class="secondary" type="button" disabled>
       <span aria-hidden="true">⬇️</span>
@@ -192,83 +377,6 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-  <script>
-    const qrWrapper = document.getElementById('qr-wrapper');
-    const form = document.getElementById('qr-form');
-    const urlInput = document.getElementById('qr-url');
-    const downloadButton = document.getElementById('download-btn');
-    let qrCodeInstance = null;
-
-    function resetQrWrapper() {
-      qrWrapper.innerHTML = '';
-      qrWrapper.classList.remove('empty');
-    }
-
-    function createQrCode(url) {
-      resetQrWrapper();
-      qrCodeInstance = new QRCode(qrWrapper, {
-        text: url,
-        width: 220,
-        height: 220,
-        colorDark: '#1f2937',
-        colorLight: '#ffffff',
-        correctLevel: QRCode.CorrectLevel.H,
-      });
-    }
-
-    function enableDownload() {
-      const canvas = qrWrapper.querySelector('canvas');
-      const image = qrWrapper.querySelector('img');
-      if (!canvas && !image) {
-        downloadButton.disabled = true;
-        return;
-      }
-
-      downloadButton.disabled = false;
-      downloadButton.onclick = () => {
-        let dataUrl = '';
-        if (canvas) {
-          dataUrl = canvas.toDataURL('image/png');
-        } else if (image) {
-          // Some browsers render the QR as an image element
-          const tempCanvas = document.createElement('canvas');
-          tempCanvas.width = image.width;
-          tempCanvas.height = image.height;
-          const ctx = tempCanvas.getContext('2d');
-          ctx.drawImage(image, 0, 0);
-          dataUrl = tempCanvas.toDataURL('image/png');
-        }
-
-        const link = document.createElement('a');
-        link.href = dataUrl;
-        link.download = 'j1hub-qr.png';
-        link.click();
-      };
-    }
-
-    form.addEventListener('submit', (event) => {
-      event.preventDefault();
-      const url = urlInput.value.trim();
-
-      if (!url) {
-        qrWrapper.textContent = 'Please enter a valid URL to generate a QR code.';
-        qrWrapper.classList.add('empty');
-        downloadButton.disabled = true;
-        return;
-      }
-
-      qrWrapper.innerHTML = '';
-      qrWrapper.classList.remove('empty');
-
-      if (qrCodeInstance) {
-        qrCodeInstance.clear();
-      }
-
-      createQrCode(url);
-
-      // Allow QRCode.js time to render before enabling download
-      setTimeout(enableDownload, 50);
-    });
-  </script>
+  <script type="module" src="js/qr.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add property/language aware QR builder UI with quick presets in `qr.html`
- move generator logic into `js/qr.js` with analytics pixel logging and copy/download helpers
- provide Apps Script hit logger implementation and deployment guide in docs

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e770536e608333801a307e20a01f3c