### PR TITLE
feat: add read-only admin dashboard tiles

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2,324 +2,401 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="manifest" href="manifest.json">
-  <meta name="theme-color" content="#007BFF">
-  <script>
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('service-worker.js');
-    }
-  </script>
-  <title>Admin Panel</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="manifest.json" />
+  <meta name="theme-color" content="#4f46e5" />
+  <title>J1 Hub · Admin Dashboard</title>
   <style>
+    :root {
+      color-scheme: light;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
-      font-family: Arial, sans-serif;
       margin: 0;
-      padding: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background-color: #f8fafc;
+      color: #0f172a;
       min-height: 100vh;
-      background-color: #f5f5f5;
+      display: flex;
+      flex-direction: column;
     }
 
-    .admin-container {
-      display: none;
-      background-color: #ffffff;
-      padding: 2rem;
-      border-radius: 8px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      width: 100%;
-      max-width: 480px;
+    .page-header {
+      padding: 1.5rem clamp(1rem, 4vw, 2.5rem) 1rem;
+      background: linear-gradient(135deg, #4f46e5, #7c3aed);
+      color: #ffffff;
+      text-align: left;
     }
 
-    h1 {
-      margin-bottom: 1.5rem;
-      text-align: center;
+    .page-header h1 {
+      margin: 0;
+      font-size: clamp(1.5rem, 4vw, 2.5rem);
+      font-weight: 600;
     }
 
-    form {
+    .page-header p {
+      margin: 0.5rem 0 0;
+      max-width: 46rem;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+
+    main {
+      flex: 1;
+      padding: clamp(1rem, 3vw, 2.5rem);
+    }
+
+    .dashboard-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      align-items: stretch;
+    }
+
+    .dashboard-tile {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 1.5rem;
+      box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.45);
       display: flex;
       flex-direction: column;
       gap: 1rem;
     }
 
-    label {
+    .dashboard-tile header h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .dashboard-tile header p {
+      margin: 0.25rem 0 0;
+      color: #475569;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: #ffffff;
+      font-size: 0.95rem;
+    }
+
+    thead th {
+      text-align: left;
+      padding: 0.65rem 0.75rem;
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #64748b;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    tbody td {
+      padding: 0.75rem;
+      border-bottom: 1px solid #f1f5f9;
+      color: #1e293b;
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .table-wrapper {
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .empty-state,
+    .error-state {
+      margin: 0;
+      padding: 1rem;
+      border-radius: 12px;
+      background: #f8fafc;
+      border: 1px dashed #cbd5f5;
+      color: #475569;
+      font-size: 0.95rem;
+    }
+
+    .info-note {
+      margin: 0;
+      padding: 0.9rem 1.1rem;
+      border-radius: 12px;
+      background: rgba(79, 70, 229, 0.08);
+      border: 1px solid rgba(79, 70, 229, 0.16);
+      color: #312e81;
+      font-size: 0.95rem;
+    }
+
+    .primary-link,
+    .secondary-link,
+    .copy-button,
+    .action-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 12px;
+      padding: 0.9rem 1.1rem;
+      font-size: 1rem;
+      font-weight: 600;
+      text-decoration: none;
+      cursor: pointer;
+      transition: transform 0.1s ease, box-shadow 0.1s ease;
+      text-align: center;
+    }
+
+    .primary-link,
+    .action-button {
+      background: #4f46e5;
+      color: #ffffff;
+      border: none;
+      box-shadow: 0 12px 24px -18px rgba(79, 70, 229, 0.7);
+    }
+
+    .secondary-link {
+      background: rgba(79, 70, 229, 0.12);
+      color: #312e81;
+      border: 1px solid rgba(79, 70, 229, 0.15);
+    }
+
+    .copy-button {
+      background: #1e293b;
+      color: #ffffff;
+      border: none;
+      min-width: 96px;
+    }
+
+    .primary-link:hover,
+    .primary-link:focus,
+    .secondary-link:hover,
+    .secondary-link:focus,
+    .copy-button:hover,
+    .copy-button:focus,
+    .action-button:hover,
+    .action-button:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px -18px rgba(15, 23, 42, 0.35);
+      outline: none;
+    }
+
+    .primary-link:focus,
+    .secondary-link:focus,
+    .copy-button:focus,
+    .action-button:focus {
+      box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.5);
+    }
+
+    .primary-link[aria-disabled="true"] {
+      pointer-events: none;
+      opacity: 0.6;
+    }
+
+    .copy-field {
       display: flex;
       flex-direction: column;
-      font-weight: 600;
-      text-align: left;
-      gap: 0.5rem;
+      gap: 0.35rem;
+      font-size: 0.9rem;
+      color: #475569;
     }
 
-    input {
-      padding: 0.65rem;
-      border: 1px solid #cccccc;
-      border-radius: 4px;
-      font-size: 1rem;
-    }
-
-    input:focus {
-      outline: none;
-      border-color: #007bff;
-      box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.15);
-    }
-
-    .actions {
+    .copy-row {
       display: flex;
-      gap: 0.75rem;
+      gap: 0.65rem;
       flex-wrap: wrap;
     }
 
-    button {
-      flex: 1 1 200px;
-      padding: 0.75rem 1.5rem;
-      font-size: 1rem;
-      color: #ffffff;
-      background-color: #007bff;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      transition: background-color 0.2s ease-in-out;
+    .copy-row input {
+      flex: 1;
+      min-width: 180px;
+      border-radius: 10px;
+      border: 1px solid #cbd5f5;
+      padding: 0.85rem 0.9rem;
+      font-size: 0.95rem;
+      background: #f8fafc;
+      color: #1e293b;
     }
 
-    button:hover {
-      background-color: #0056b3;
-    }
-
-    .slug-preview {
+    .event-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
       display: flex;
-      align-items: center;
-      justify-content: space-between;
+      flex-direction: column;
       gap: 0.75rem;
-      background-color: #eef2ff;
-      border-radius: 6px;
-      padding: 0.75rem 1rem;
-      font-size: 0.95rem;
     }
 
-    .slug-preview strong {
-      font-size: 1rem;
-      color: #1f2933;
+    .event-list li {
+      border-radius: 12px;
+      border: 1px solid #e2e8f0;
+      padding: 0.9rem 1rem;
+      background: #f8fafc;
     }
 
-    .slug-value {
-      font-family: 'Courier New', Courier, monospace;
+    .event-title {
+      display: block;
       font-weight: 600;
-      color: #4f46e5;
-      word-break: break-all;
+      color: #1e293b;
+      margin-bottom: 0.35rem;
     }
 
-    .secondary-button {
-      flex: 0 0 auto;
-      min-width: 120px;
-      background-color: #4338ca;
+    .event-meta {
+      font-size: 0.85rem;
+      color: #475569;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 0.65rem;
     }
 
-    .secondary-button:hover {
-      background-color: #312e81;
+    .event-meta span:last-child {
+      font-weight: 600;
     }
 
-    .message {
-      margin-top: 1rem;
-      font-size: 0.95rem;
-      text-align: center;
+    .links-stack {
+      display: flex;
+      flex-direction: column;
+      gap: 0.65rem;
     }
 
-    .tip {
-      margin-top: 0.75rem;
-      font-size: 0.9rem;
-      color: #4338ca;
-      text-align: center;
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (min-width: 720px) {
+      main {
+        padding-bottom: 3rem;
+      }
     }
   </style>
-</head>
-<body>
-  <div class="admin-container" id="admin-container">
-    <h1>Admin Panel</h1>
-    <form id="hotel-form" novalidate>
-      <label>
-        Hotel Name
-        <input type="text" id="hotel-name" name="hotel-name" required />
-      </label>
-      <label>
-        Address
-        <input type="text" id="hotel-address" name="hotel-address" required />
-      </label>
-      <label>
-        Phone
-        <input type="tel" id="hotel-phone" name="hotel-phone" required />
-      </label>
-      <label>
-        Website
-        <input type="url" id="hotel-website" name="hotel-website" required />
-      </label>
-      <div class="actions">
-        <button type="submit">Save Hotel</button>
-        <button type="button" id="preview-button">View Preview</button>
-      </div>
-      <div class="slug-preview" id="slug-preview" hidden>
-        <div>
-          <strong>Recommended slug:</strong>
-          <span class="slug-value" id="slug-value"></span>
-        </div>
-        <button
-          type="button"
-          id="copy-slug-button"
-          class="secondary-button"
-          aria-label="Copy recommended slug"
-        >
-          Copy slug
-        </button>
-      </div>
-      <p class="tip" id="slug-tip" hidden>Add this hotel to hotels.json via PR later.</p>
-      <p class="message" id="form-message" role="status" aria-live="polite"></p>
-    </form>
-  </div>
-
   <script>
-    (function () {
-      const password = prompt("Enter admin password:");
-      if (password === null) {
-        window.location.href = "index.html";
-        return;
-      }
-
-      if (password === "J1secure2025") {
-        const container = document.getElementById("admin-container");
-        if (!container) {
-          return;
-        }
-
-        container.style.display = "block";
-
-        const form = document.getElementById("hotel-form");
-        const messageEl = document.getElementById("form-message");
-        const previewButton = document.getElementById("preview-button");
-        const slugPreview = document.getElementById("slug-preview");
-        const slugValueEl = document.getElementById("slug-value");
-        const copySlugButton = document.getElementById("copy-slug-button");
-        const slugTip = document.getElementById("slug-tip");
-
-        const slugify = (value = "") =>
-          value
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/^-+|-+$/g, "");
-
-        const getFormData = () => {
-          const name = document.getElementById("hotel-name").value.trim();
-          const address = document.getElementById("hotel-address").value.trim();
-          const phone = document.getElementById("hotel-phone").value.trim();
-          const website = document.getElementById("hotel-website").value.trim();
-
-          return { name, address, phone, website };
-        };
-
-        const showMessage = (text, type = "success") => {
-          if (!messageEl) return;
-          messageEl.textContent = text;
-          messageEl.style.color = type === "error" ? "#c0392b" : "#27ae60";
-        };
-
-        const resetMessage = () => {
-          if (messageEl) {
-            messageEl.textContent = "";
-          }
-        };
-
-        const setSlugPreview = (slug) => {
-          if (!slugPreview || !slugValueEl || !slugTip || !copySlugButton) {
-            return;
-          }
-
-          if (!slug) {
-            slugPreview.hidden = true;
-            slugTip.hidden = true;
-            copySlugButton.disabled = true;
-            copySlugButton.removeAttribute("data-slug");
-            return;
-          }
-
-          slugPreview.hidden = false;
-          slugTip.hidden = false;
-          slugValueEl.textContent = slug;
-          copySlugButton.disabled = false;
-          copySlugButton.setAttribute("data-slug", slug);
-          copySlugButton.setAttribute("aria-label", `Copy recommended slug ${slug}`);
-        };
-
-        const copySlugToClipboard = async (slug) => {
-          if (!slug) {
-            return "No slug generated.";
-          }
-
-          try {
-            await navigator.clipboard.writeText(slug);
-            return `Recommended slug copied to clipboard: ${slug}`;
-          } catch (error) {
-            console.warn("Unable to copy slug automatically.", error);
-            return `Recommended slug ready: ${slug} (copy manually)`;
-          }
-        };
-
-        if (copySlugButton) {
-          copySlugButton.addEventListener("click", async () => {
-            const slug = copySlugButton.getAttribute("data-slug") || "";
-            const message = await copySlugToClipboard(slug);
-            showMessage(message);
-          });
-        }
-
-        form.addEventListener("submit", async (event) => {
-          event.preventDefault();
-          resetMessage();
-
-          const { name, address, phone, website } = getFormData();
-
-          if (!name || !address || !phone || !website) {
-            showMessage("Please fill in all required fields.", "error");
-            return;
-          }
-
-          try {
-            const stored = window.localStorage.getItem("hotels");
-            const hotels = stored ? JSON.parse(stored) : [];
-
-            const newHotel = {
-              name,
-              address,
-              phone,
-              website,
-              createdAt: new Date().toISOString(),
-            };
-
-            hotels.push(newHotel);
-            window.localStorage.setItem("hotels", JSON.stringify(hotels));
-
-            const recommendedSlug = slugify(name);
-            setSlugPreview(recommendedSlug);
-            const copyMessage = await copySlugToClipboard(recommendedSlug);
-
-            showMessage(`Hotel saved to local preview list. ${copyMessage}`);
-            form.reset();
-          } catch (error) {
-            console.error("Failed to save hotel:", error);
-            showMessage("Unable to save hotel details. Please try again.", "error");
-          }
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('service-worker.js').catch(() => {
+          /* noop */
         });
-
-        previewButton.addEventListener("click", () => {
-          const previewData = getFormData();
-          console.log("Preview hotel data:", previewData);
-          const previewSlug = slugify(previewData.name || "");
-          setSlugPreview(previewSlug);
-          showMessage("Preview data logged to console.");
-        });
-      } else {
-        window.location.href = "index.html";
-      }
-    })();
+      });
+    }
   </script>
+</head>
+<body
+  data-hit-sheet-url="https://docs.google.com/spreadsheets/d/YOUR_HITLOGGER_SHEET_ID/edit#gid=0"
+  data-checkin-readme="docs/checkin/README.md"
+>
+  <header class="page-header">
+    <h1>Admin Dashboard</h1>
+    <p>
+      Quick read-only snapshots pulled from local data on this device. Use these tiles to confirm local onboarding progress,
+      RSVP activity, and deployment links while getting the live dashboards in place.
+    </p>
+  </header>
+
+  <main>
+    <div class="dashboard-grid">
+      <section class="dashboard-tile" id="onboarding-tile">
+        <header>
+          <h2>Onboarding Completions (local estimate)</h2>
+          <p>Counts are based on onboarding progress stored in this browser&rsquo;s localStorage.</p>
+        </header>
+        <div class="tile-body">
+          <div class="table-wrapper" aria-live="polite">
+            <table aria-describedby="onboarding-summary">
+              <thead>
+                <tr>
+                  <th scope="col">Property</th>
+                  <th scope="col">Tasks Completed</th>
+                  <th scope="col">Checklist Opened</th>
+                </tr>
+              </thead>
+              <tbody id="onboarding-table-body"></tbody>
+            </table>
+          </div>
+          <p class="empty-state" id="onboarding-empty" hidden>
+            No onboarding data stored on this device yet. Ask a teammate to walk through the checklist to populate this demo.
+          </p>
+          <p class="error-state" id="onboarding-error" hidden>
+            Unable to read onboarding storage. Check that this browser allows local data for the site.
+          </p>
+          <p id="onboarding-summary" class="sr-only"></p>
+        </div>
+      </section>
+
+      <section class="dashboard-tile" id="events-tile">
+        <header>
+          <h2>Events this week</h2>
+          <p>Upcoming events from <code>data/events.json</code> with RSVP state saved on this device.</p>
+        </header>
+        <div class="tile-body">
+          <p id="events-summary" class="info-note" hidden></p>
+          <p class="error-state" id="events-error" hidden>
+            Couldn&rsquo;t load events. Try again after checking your connection or running the site from a local server.
+          </p>
+          <ul class="event-list" id="events-list" aria-live="polite"></ul>
+        </div>
+      </section>
+
+      <section class="dashboard-tile" id="analytics-tile">
+        <header>
+          <h2>Scan Analytics</h2>
+          <p>Open the hitlogger Google Sheet and share it with staff running scanners.</p>
+        </header>
+        <div class="tile-body links-stack">
+          <a
+            id="scan-analytics-link"
+            class="primary-link"
+            href="#"
+            target="_blank"
+            rel="noopener"
+          >Open Google Sheet</a>
+          <label class="copy-field" for="scan-analytics-url">
+            <span>Shareable URL</span>
+            <div class="copy-row">
+              <input id="scan-analytics-url" type="text" readonly value="" />
+              <button class="copy-button" type="button" data-copy-target="scan-analytics-url">Copy URL</button>
+            </div>
+          </label>
+          <a class="secondary-link" href="docs/analytics/README.md" target="_blank" rel="noopener">
+            View analytics setup guide
+          </a>
+        </div>
+      </section>
+
+      <section class="dashboard-tile" id="checkin-tile">
+        <header>
+          <h2>Check-in Webhook</h2>
+          <p>Follow the deployment guide before staff scanners go live.</p>
+        </header>
+        <div class="tile-body links-stack">
+          <a
+            id="checkin-readme-link"
+            class="primary-link"
+            href="docs/checkin/README.md"
+            target="_blank"
+            rel="noopener"
+          >Open deployment README</a>
+          <a class="secondary-link" href="apps-script/Code.gs" target="_blank" rel="noopener">
+            Download Apps Script code</a
+          >
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <div class="sr-only" id="dashboard-status" role="status" aria-live="polite"></div>
+
+  <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,402 @@
+const RSVP_STORAGE_KEY = 'events:rsvp';
+const ANALYTICS_STORAGE_KEY = 'admin:hitSheetUrl';
+
+const onboardingTableBody = document.getElementById('onboarding-table-body');
+const onboardingEmptyState = document.getElementById('onboarding-empty');
+const onboardingErrorState = document.getElementById('onboarding-error');
+const onboardingSummary = document.getElementById('onboarding-summary');
+
+const eventsList = document.getElementById('events-list');
+const eventsSummary = document.getElementById('events-summary');
+const eventsError = document.getElementById('events-error');
+
+const scanAnalyticsLink = document.getElementById('scan-analytics-link');
+const scanAnalyticsInput = document.getElementById('scan-analytics-url');
+const checkinReadmeLink = document.getElementById('checkin-readme-link');
+
+const statusRegion = document.getElementById('dashboard-status');
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderOnboardingTile();
+  renderEventsTile();
+  hydrateScanAnalyticsTile();
+  hydrateCheckinTile();
+  attachCopyHandlers();
+});
+
+function renderOnboardingTile() {
+  if (!onboardingTableBody) {
+    return;
+  }
+
+  clearChildren(onboardingTableBody);
+  hide(onboardingEmptyState);
+  hide(onboardingErrorState);
+
+  const result = readOnboardingStats();
+
+  if (result.error) {
+    show(onboardingErrorState);
+    onboardingErrorState.textContent = result.error;
+    announce(result.error);
+    return;
+  }
+
+  const stats = result.stats;
+
+  if (!stats.length) {
+    show(onboardingEmptyState);
+    onboardingSummary.textContent = 'No onboarding completions saved in localStorage yet.';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  stats.forEach((entry) => {
+    const row = document.createElement('tr');
+
+    const propertyCell = document.createElement('td');
+    propertyCell.textContent = entry.property;
+    propertyCell.setAttribute('data-label', 'Property');
+
+    const completedCell = document.createElement('td');
+    completedCell.textContent = String(entry.completedCount);
+    completedCell.setAttribute('data-label', 'Tasks completed');
+
+    const seenCell = document.createElement('td');
+    seenCell.textContent = entry.hasSeen ? 'Yes' : 'No';
+    seenCell.setAttribute('data-label', 'Checklist opened');
+
+    row.appendChild(propertyCell);
+    row.appendChild(completedCell);
+    row.appendChild(seenCell);
+
+    fragment.appendChild(row);
+  });
+
+  onboardingTableBody.appendChild(fragment);
+  onboardingSummary.textContent = `${stats.length} properties with onboarding data detected.`;
+}
+
+function readOnboardingStats() {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return { stats: [], error: 'Storage unavailable in this environment.' };
+  }
+
+  try {
+    const prefix = 'onboarding.';
+    const suffix = '.completed';
+    const statsByProperty = new Map();
+    const length = window.localStorage.length;
+
+    for (let index = 0; index < length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (!key || !key.startsWith(prefix) || !key.endsWith(suffix)) {
+        continue;
+      }
+
+      const propertyCode = key.slice(prefix.length, -suffix.length);
+      let completedCount = 0;
+
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            completedCount = parsed.length;
+          }
+        }
+      } catch (error) {
+        console.warn('Unable to parse onboarding completions', error);
+      }
+
+      const normalizedProperty = propertyCode.toUpperCase();
+      const existing = statsByProperty.get(normalizedProperty) || { completedCount: 0, hasSeen: false };
+      existing.completedCount = Math.max(existing.completedCount, completedCount);
+      statsByProperty.set(normalizedProperty, existing);
+    }
+
+    statsByProperty.forEach((value, property) => {
+      const seenKey = `onboarding.${property}.seen`;
+      try {
+        value.hasSeen = window.localStorage.getItem(seenKey) === 'true';
+      } catch (error) {
+        value.hasSeen = false;
+      }
+    });
+
+    const stats = Array.from(statsByProperty.entries())
+      .map(([property, value]) => ({ property, ...value }))
+      .sort((a, b) => a.property.localeCompare(b.property));
+
+    return { stats };
+  } catch (error) {
+    console.warn('Unable to load onboarding stats', error);
+    return { stats: [], error: 'Unable to read onboarding progress from localStorage.' };
+  }
+}
+
+async function renderEventsTile() {
+  if (!eventsList) {
+    return;
+  }
+
+  clearChildren(eventsList);
+  hide(eventsError);
+  hide(eventsSummary);
+
+  const rsvpState = loadRsvpState();
+
+  try {
+    const response = await fetch('data/events.json', { cache: 'no-cache' });
+    if (!response.ok) {
+      throw new Error(`Failed to load events (status ${response.status})`);
+    }
+
+    const events = await response.json();
+    const thisWeeksEvents = filterEventsForCurrentWeek(events);
+
+    if (!thisWeeksEvents.length) {
+      eventsSummary.textContent = 'No events scheduled for this week in the local dataset yet.';
+      show(eventsSummary);
+      announce(eventsSummary.textContent);
+      return;
+    }
+
+    const rsvpedEvents = thisWeeksEvents.filter((event) => Boolean(rsvpState[event.id]));
+
+    eventsSummary.textContent = `${rsvpedEvents.length} of ${thisWeeksEvents.length} events RSVP’d on this device.`;
+    show(eventsSummary);
+
+    const fragment = document.createDocumentFragment();
+    thisWeeksEvents.forEach((event) => {
+      fragment.appendChild(renderEventListItem(event, Boolean(rsvpState[event.id])));
+    });
+
+    eventsList.appendChild(fragment);
+  } catch (error) {
+    console.warn('Unable to render events tile', error);
+    show(eventsError);
+    announce('Events data could not be loaded.');
+  }
+}
+
+function filterEventsForCurrentWeek(events) {
+  const now = new Date();
+  const startOfWeek = new Date(now);
+  startOfWeek.setHours(0, 0, 0, 0);
+  const currentDay = startOfWeek.getDay();
+  const diffToMonday = (currentDay + 6) % 7;
+  startOfWeek.setDate(startOfWeek.getDate() - diffToMonday);
+
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(endOfWeek.getDate() + 7);
+
+  return events.filter((event) => {
+    const start = new Date(event.start);
+    if (Number.isNaN(start.getTime())) {
+      return false;
+    }
+    return start >= startOfWeek && start < endOfWeek;
+  });
+}
+
+function renderEventListItem(event, isRsvped) {
+  const listItem = document.createElement('li');
+
+  const title = document.createElement('span');
+  title.className = 'event-title';
+  title.textContent = event.title || 'Untitled event';
+
+  const meta = document.createElement('div');
+  meta.className = 'event-meta';
+  const formattedStart = formatEventDate(event.start);
+  const venue = event.venue ? String(event.venue) : 'Venue TBA';
+  const rsvpLabel = isRsvped ? 'RSVP’d here' : 'Not RSVP’d yet';
+
+  const dateSpan = document.createElement('span');
+  dateSpan.textContent = formattedStart;
+
+  const venueSpan = document.createElement('span');
+  venueSpan.textContent = venue;
+
+  const rsvpSpan = document.createElement('span');
+  rsvpSpan.textContent = rsvpLabel;
+
+  meta.appendChild(dateSpan);
+  meta.appendChild(venueSpan);
+  meta.appendChild(rsvpSpan);
+
+  listItem.appendChild(title);
+  listItem.appendChild(meta);
+
+  return listItem;
+}
+
+function formatEventDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown date';
+  }
+
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  return `${dateFormatter.format(date)} · ${timeFormatter.format(date)}`;
+}
+
+function loadRsvpState() {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(RSVP_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return {};
+  } catch (error) {
+    console.warn('Unable to parse RSVP storage', error);
+    return {};
+  }
+}
+
+function hydrateScanAnalyticsTile() {
+  const fallbackUrl = 'https://docs.google.com/spreadsheets/';
+  const configUrl = document.body?.dataset.hitSheetUrl || '';
+  const storedUrl = readLocalValue(ANALYTICS_STORAGE_KEY);
+  const url = storedUrl || configUrl || fallbackUrl;
+
+  if (scanAnalyticsInput) {
+    scanAnalyticsInput.value = url;
+  }
+
+  if (scanAnalyticsLink) {
+    if (url && url !== '#') {
+      scanAnalyticsLink.href = url;
+      scanAnalyticsLink.removeAttribute('aria-disabled');
+    } else {
+      scanAnalyticsLink.href = '#';
+      scanAnalyticsLink.setAttribute('aria-disabled', 'true');
+    }
+  }
+}
+
+function hydrateCheckinTile() {
+  const configuredUrl = document.body?.dataset.checkinReadme;
+  if (checkinReadmeLink && configuredUrl) {
+    checkinReadmeLink.href = configuredUrl;
+  }
+}
+
+function attachCopyHandlers() {
+  const copyButtons = document.querySelectorAll('[data-copy-target]');
+  copyButtons.forEach((button) => {
+    button.addEventListener('click', async () => {
+      const targetId = button.getAttribute('data-copy-target');
+      if (!targetId) {
+        return;
+      }
+
+      const input = document.getElementById(targetId);
+      if (!input) {
+        return;
+      }
+
+      const textToCopy = input.value;
+      if (!textToCopy) {
+        announce('Nothing to copy yet.');
+        return;
+      }
+
+      const success = await copyToClipboard(textToCopy, input);
+      if (success) {
+        announce('Link copied to clipboard.');
+      } else {
+        announce('Copy failed. Select the text and copy manually.');
+      }
+    });
+  });
+}
+
+async function copyToClipboard(text, input) {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.warn('Clipboard API failed, trying fallback', error);
+    }
+  }
+
+  try {
+    const wasReadOnly = input.hasAttribute('readonly');
+    if (wasReadOnly) {
+      input.removeAttribute('readonly');
+    }
+    input.select();
+    const successful = document.execCommand('copy');
+    input.setSelectionRange(0, 0);
+    if (wasReadOnly) {
+      input.setAttribute('readonly', '');
+    }
+    return successful;
+  } catch (error) {
+    console.warn('Fallback clipboard copy failed', error);
+    return false;
+  }
+}
+
+function readLocalValue(key) {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return '';
+  }
+
+  try {
+    return window.localStorage.getItem(key) || '';
+  } catch (error) {
+    return '';
+  }
+}
+
+function hide(element) {
+  if (element) {
+    element.hidden = true;
+  }
+}
+
+function show(element) {
+  if (element) {
+    element.hidden = false;
+  }
+}
+
+function clearChildren(element) {
+  if (!element) {
+    return;
+  }
+
+  while (element.firstChild) {
+    element.removeChild(element.firstChild);
+  }
+}
+
+function announce(message) {
+  if (!statusRegion) {
+    return;
+  }
+  statusRegion.textContent = message;
+}


### PR DESCRIPTION
## Summary
- replace the admin landing page with a mobile-first grid of read-only tiles for onboarding, events, scan analytics, and check-in deployment links
- add a lightweight admin.js bundle that reads localStorage for onboarding completions and RSVP counts while hydrating analytics/check-in links
- provide clipboard helpers and accessible status messaging to make the demo dashboard useful out of the box

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68e773f08748833396003d5995e55a04