### PR TITLE
Add release helper script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,39 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$REPO_ROOT"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SERVICE_WORKER="$REPO_ROOT/service-worker.js"
 
-SERVICE_WORKER="service-worker.js"
 if [[ ! -f "$SERVICE_WORKER" ]]; then
-  echo "Error: $SERVICE_WORKER not found in repository root." >&2
+  echo "service-worker.js not found at $SERVICE_WORKER" >&2
   exit 1
 fi
 
-read -rp "Enter version suffix (e.g., 2024.04): " SUFFIX
+read -rp "Enter release version suffix (e.g., 6 or 2024.03): " SUFFIX
+
 if [[ -z "${SUFFIX// }" ]]; then
-  echo "Error: version suffix cannot be empty." >&2
+  echo "Version suffix cannot be empty." >&2
   exit 1
 fi
 
-CACHE_VERSION="j1hub-v${SUFFIX}"
-RELEASE_TAG="v${SUFFIX}"
+NEW_CACHE_VERSION="j1hub-v${SUFFIX}"
 
-if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" > /dev/null; then
-  echo "Error: tag ${RELEASE_TAG} already exists." >&2
+if ! grep -q 'const CACHE_VERSION = "j1hub-' "$SERVICE_WORKER"; then
+  echo "Unable to locate CACHE_VERSION declaration in $SERVICE_WORKER" >&2
   exit 1
 fi
 
-# Update CACHE_VERSION in the service worker
-perl -0pi -e "s/const CACHE_VERSION = \".*?\";/const CACHE_VERSION = \"${CACHE_VERSION//\//\\/}\";/" "$SERVICE_WORKER"
+sed -i.bak "s/const CACHE_VERSION = \"j1hub-v[^\"]*\";/const CACHE_VERSION = \"${NEW_CACHE_VERSION}\";/" "$SERVICE_WORKER"
+rm "$SERVICE_WORKER.bak"
 
-# Stage, commit, tag, and push the release
-git add -A
-git commit -m "release: ${RELEASE_TAG}" || {
-  echo "Nothing to commit." >&2
-  exit 1
-}
-
-git tag "$RELEASE_TAG"
-git push --follow-tags
+git -C "$REPO_ROOT" add -A
+git -C "$REPO_ROOT" commit -m "release: v${SUFFIX}"
+git -C "$REPO_ROOT" tag "v${SUFFIX}"
+git -C "$REPO_ROOT" push --follow-tags


### PR DESCRIPTION
## Summary
- add a release helper script that bumps the service worker cache version and pushes a tagged release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e77f4f15188333b4d7d17ba97dc0dd